### PR TITLE
Experimental - Don't load items every inventory load.

### DIFF
--- a/build/build.properties
+++ b/build/build.properties
@@ -2,4 +2,4 @@ mc_version=1.7.10
 forge_version=10.13.4.1614-1.7.10
 ccl_version=1.1.3.138
 ccc_version=1.0.7.+
-mod_version=2.0.0-pre-12-GTNH
+mod_version=2.0.0-pre-13-GTNH

--- a/src/codechicken/nei/ItemList.java
+++ b/src/codechicken/nei/ItemList.java
@@ -182,6 +182,7 @@ public class ItemList
 
         @Override
         public void execute() {
+            // System.out.println("Executing NEI Item Loading");
             ThreadOperationTimer timer = getTimer(500);
 
             LinkedList<ItemStack> items = new LinkedList<>();
@@ -243,6 +244,7 @@ public class ItemList
     {
         @Override
         public void execute() {
+            // System.out.println("Executing NEI Item Filtering");
             ArrayList<ItemStack> filtered = new ArrayList<>();
             ItemFilter filter = getItemListFilter();
 

--- a/src/codechicken/nei/LayoutManager.java
+++ b/src/codechicken/nei/LayoutManager.java
@@ -100,6 +100,7 @@ public class LayoutManager implements IContainerInputHandler, IContainerTooltipH
     public static HashMap<Integer, LayoutStyle> layoutStyles = new HashMap<>();
 
     public static boolean ftbUtilsLoaded = false;
+    public static boolean itemsLoaded = false;
 
     public static void load() {
         ftbUtilsLoaded = Loader.isModLoaded("FTBU");
@@ -559,7 +560,10 @@ public class LayoutManager implements IContainerInputHandler, IContainerTooltipH
         if (isEnabled()) {
             setInputFocused(null);
 
-            ItemList.loadItems.restart();
+            if(!itemsLoaded) {
+                ItemList.loadItems.restart();
+                itemsLoaded = true;
+            }
             overlayRenderer = null;
 
             getLayoutStyle().init();

--- a/src/codechicken/nei/SubsetWidget.java
+++ b/src/codechicken/nei/SubsetWidget.java
@@ -518,12 +518,15 @@ public class SubsetWidget extends Button implements ItemFilterProvider, ItemsLoa
         }
 
         public synchronized void reallocate() {
+            // System.out.println("NEI Subset - Reallocate");
+            // Thread.dumpStack();
             reallocate = true;
             restart();
         }
 
         @Override
         public void execute() {
+            // System.out.println("Executing NEI Subset Item Allocation");
             HashMap<String, SubsetState> state = new HashMap<>();
             List<SubsetTag> tags = new LinkedList<>();
             synchronized (root) {


### PR DESCRIPTION
Stop running the LoadItem task on every inventory open (which also reran the search and caused lag on every inventory open).

Unclear if this breaks anything -- it works with simple testing.