### PR TITLE
Parallalize recipe handlers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ minecraft {
     version = config.mc_version + "-" + config.forge_version
 }
 
-def root = project.projectDir.parentFile
+def root = project.projectDir
 sourceSets {
     main {
         java {

--- a/src/codechicken/nei/recipe/GuiCraftingRecipe.java
+++ b/src/codechicken/nei/recipe/GuiCraftingRecipe.java
@@ -23,11 +23,15 @@ public class GuiCraftingRecipe extends GuiRecipe
         GuiContainer prevscreen = mc.currentScreen instanceof GuiContainer ? (GuiContainer) mc.currentScreen : null;
 
         ArrayList<ICraftingHandler> handlers;
+        TaskProfiler profiler = ProfilerRecipeHandler.getProfiler();
         try {
+            profiler.start("recipe.concurrent.crafting");
             handlers = forkJoinPool.submit(() -> getCraftingHandlers(outputId, results)).get();
         } catch (InterruptedException | ExecutionException e) {
             e.printStackTrace();
             return false;
+        } finally {
+            profiler.end();
         }
 
         if (handlers.isEmpty())

--- a/src/codechicken/nei/recipe/GuiCraftingRecipe.java
+++ b/src/codechicken/nei/recipe/GuiCraftingRecipe.java
@@ -6,6 +6,9 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiContainer;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class GuiCraftingRecipe extends GuiRecipe
 {
@@ -13,15 +16,11 @@ public class GuiCraftingRecipe extends GuiRecipe
         Minecraft mc = NEIClientUtils.mc();
         GuiContainer prevscreen = mc.currentScreen instanceof GuiContainer ? (GuiContainer) mc.currentScreen : null;
 
-        TaskProfiler profiler = ProfilerRecipeHandler.getProfiler();
-        ArrayList<ICraftingHandler> handlers = new ArrayList<>();
-        for (ICraftingHandler craftinghandler : craftinghandlers) {
-            profiler.start(craftinghandler.getRecipeName());
-            ICraftingHandler handler = craftinghandler.getRecipeHandler(outputId, results);
-            if (handler.numRecipes() > 0)
-                handlers.add(handler);
-        }
-        profiler.end();
+        ArrayList<ICraftingHandler> handlers = craftinghandlers.parallelStream()
+            .map(h -> h.getRecipeHandler(outputId, results))
+            .filter(h -> h.numRecipes() > 0)
+            .collect(Collectors.toCollection(ArrayList::new));
+
         if (handlers.isEmpty())
             return false;
 

--- a/src/codechicken/nei/recipe/GuiCraftingRecipe.java
+++ b/src/codechicken/nei/recipe/GuiCraftingRecipe.java
@@ -1,6 +1,7 @@
 package codechicken.nei.recipe;
 
 import codechicken.core.TaskProfiler;
+import codechicken.nei.ItemList;
 import codechicken.nei.NEIClientUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiContainer;
@@ -26,7 +27,7 @@ public class GuiCraftingRecipe extends GuiRecipe
         TaskProfiler profiler = ProfilerRecipeHandler.getProfiler();
         try {
             profiler.start("recipe.concurrent.crafting");
-            handlers = forkJoinPool.submit(() -> getCraftingHandlers(outputId, results)).get();
+            handlers = ItemList.forkJoinPool.submit(() -> getCraftingHandlers(outputId, results)).get();
         } catch (InterruptedException | ExecutionException e) {
             e.printStackTrace();
             return false;

--- a/src/codechicken/nei/recipe/GuiRecipe.java
+++ b/src/codechicken/nei/recipe/GuiRecipe.java
@@ -29,16 +29,6 @@ import java.util.concurrent.ForkJoinPool;
 
 public abstract class GuiRecipe extends GuiContainer implements IGuiContainerOverlay, IGuiClientSide, IGuiHandleMouseWheel, IContainerTooltipHandler
 {
-    protected static final ForkJoinPool forkJoinPool;
-
-    static {
-        int poolSize = Runtime.getRuntime().availableProcessors() * 2 / 3;
-        if (poolSize < 1)
-            poolSize = 1;
-
-        forkJoinPool = new ForkJoinPool(poolSize);
-    }
-
     public ArrayList<? extends IRecipeHandler> currenthandlers = new ArrayList<>();
 
     public int page;

--- a/src/codechicken/nei/recipe/GuiRecipe.java
+++ b/src/codechicken/nei/recipe/GuiRecipe.java
@@ -25,9 +25,20 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ForkJoinPool;
 
 public abstract class GuiRecipe extends GuiContainer implements IGuiContainerOverlay, IGuiClientSide, IGuiHandleMouseWheel, IContainerTooltipHandler
 {
+    protected static final ForkJoinPool forkJoinPool;
+
+    static {
+        int poolSize = Runtime.getRuntime().availableProcessors() * 2 / 3;
+        if (poolSize < 1)
+            poolSize = 1;
+
+        forkJoinPool = new ForkJoinPool(poolSize);
+    }
+
     public ArrayList<? extends IRecipeHandler> currenthandlers = new ArrayList<>();
 
     public int page;

--- a/src/codechicken/nei/recipe/GuiUsageRecipe.java
+++ b/src/codechicken/nei/recipe/GuiUsageRecipe.java
@@ -5,18 +5,29 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiContainer;
 
 import java.util.ArrayList;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 public class GuiUsageRecipe extends GuiRecipe
 {
+    protected static ArrayList<IUsageHandler> getUsageHandlers(String inputId, Object... ingredients) {
+        return usagehandlers.parallelStream()
+            .map(h -> h.getUsageHandler(inputId, ingredients))
+            .filter(h -> h.numRecipes() > 0)
+            .collect(Collectors.toCollection(ArrayList::new));
+    }
+
     public static boolean openRecipeGui(String inputId, Object... ingredients) {
         Minecraft mc = NEIClientUtils.mc();
         GuiContainer prevscreen = mc.currentScreen instanceof GuiContainer ? (GuiContainer) mc.currentScreen : null;
 
-        ArrayList<IUsageHandler> handlers = usagehandlers.parallelStream()
-            .map(h -> h.getUsageHandler(inputId, ingredients))
-            .filter(h -> h.numRecipes() > 0)
-            .collect(Collectors.toCollection(ArrayList::new));
+        ArrayList<IUsageHandler> handlers;
+        try {
+            handlers = forkJoinPool.submit(() -> getUsageHandlers(inputId, ingredients)).get();
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+            return false;
+        }
 
         if (handlers.isEmpty())
             return false;

--- a/src/codechicken/nei/recipe/GuiUsageRecipe.java
+++ b/src/codechicken/nei/recipe/GuiUsageRecipe.java
@@ -1,6 +1,7 @@
 package codechicken.nei.recipe;
 
 import codechicken.core.TaskProfiler;
+import codechicken.nei.ItemList;
 import codechicken.nei.NEIClientUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiContainer;
@@ -26,7 +27,7 @@ public class GuiUsageRecipe extends GuiRecipe
         TaskProfiler profiler = ProfilerRecipeHandler.getProfiler();
         try {
             profiler.start("recipe.concurrent.usage");
-            handlers = forkJoinPool.submit(() -> getUsageHandlers(inputId, ingredients)).get();
+            handlers = ItemList.forkJoinPool.submit(() -> getUsageHandlers(inputId, ingredients)).get();
         } catch (InterruptedException | ExecutionException e) {
             e.printStackTrace();
             return false;

--- a/src/codechicken/nei/recipe/GuiUsageRecipe.java
+++ b/src/codechicken/nei/recipe/GuiUsageRecipe.java
@@ -1,5 +1,6 @@
 package codechicken.nei.recipe;
 
+import codechicken.core.TaskProfiler;
 import codechicken.nei.NEIClientUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiContainer;
@@ -22,11 +23,15 @@ public class GuiUsageRecipe extends GuiRecipe
         GuiContainer prevscreen = mc.currentScreen instanceof GuiContainer ? (GuiContainer) mc.currentScreen : null;
 
         ArrayList<IUsageHandler> handlers;
+        TaskProfiler profiler = ProfilerRecipeHandler.getProfiler();
         try {
+            profiler.start("recipe.concurrent.usage");
             handlers = forkJoinPool.submit(() -> getUsageHandlers(inputId, ingredients)).get();
         } catch (InterruptedException | ExecutionException e) {
             e.printStackTrace();
             return false;
+        } finally {
+            profiler.end();
         }
 
         if (handlers.isEmpty())

--- a/src/codechicken/nei/recipe/GuiUsageRecipe.java
+++ b/src/codechicken/nei/recipe/GuiUsageRecipe.java
@@ -1,11 +1,11 @@
 package codechicken.nei.recipe;
 
-import codechicken.core.TaskProfiler;
 import codechicken.nei.NEIClientUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiContainer;
 
 import java.util.ArrayList;
+import java.util.stream.Collectors;
 
 public class GuiUsageRecipe extends GuiRecipe
 {
@@ -13,15 +13,11 @@ public class GuiUsageRecipe extends GuiRecipe
         Minecraft mc = NEIClientUtils.mc();
         GuiContainer prevscreen = mc.currentScreen instanceof GuiContainer ? (GuiContainer) mc.currentScreen : null;
 
-        TaskProfiler profiler = ProfilerRecipeHandler.getProfiler();
-        ArrayList<IUsageHandler> handlers = new ArrayList<>();
-        for (IUsageHandler usagehandler : usagehandlers) {
-            profiler.start(usagehandler.getRecipeName());
-            IUsageHandler handler = usagehandler.getUsageHandler(inputId, ingredients);
-            if (handler.numRecipes() > 0)
-                handlers.add(handler);
-        }
-        profiler.end();
+        ArrayList<IUsageHandler> handlers = usagehandlers.parallelStream()
+            .map(h -> h.getUsageHandler(inputId, ingredients))
+            .filter(h -> h.numRecipes() > 0)
+            .collect(Collectors.toCollection(ArrayList::new));
+
         if (handlers.isEmpty())
             return false;
 


### PR DESCRIPTION
This may make recipe looking up 2x-4x faster. On my i7-8650U laptop, showing recipes of GT5 circuits costs over 1s (vanilla Minecraft items are faster, costing about 500ms) with the original sequential code, and only costs about 300ms with `parallalStream`.

The profilers are removed because I have no idea how to put them into `parallalStream`. Should I keep one `profiler.start()` before the stream manipulation codes?