### PR TITLE
Backwards Compat

### DIFF
--- a/src/codechicken/nei/recipe/FuelRecipeHandler.java
+++ b/src/codechicken/nei/recipe/FuelRecipeHandler.java
@@ -17,9 +17,9 @@ public class FuelRecipeHandler extends FurnaceRecipeHandler
 {
     public class CachedFuelRecipe extends CachedRecipe
     {
-        public final FuelPair fuel;
+        public final TemplateFuelPair fuel;
 
-        public CachedFuelRecipe(FuelPair fuel) {
+        public CachedFuelRecipe(TemplateFuelPair fuel) {
             this.fuel = fuel;
         }
 
@@ -85,7 +85,7 @@ public class FuelRecipeHandler extends FurnaceRecipeHandler
     @Override
     public List<String> handleItemTooltip(GuiRecipe gui, ItemStack stack, List<String> currenttip, int recipe) {
         CachedFuelRecipe crecipe = (CachedFuelRecipe) arecipes.get(recipe);
-        FuelPair fuel = crecipe.fuel;
+        TemplateFuelPair fuel = crecipe.fuel;
         float burnTime = fuel.burnTime / 200F;
 
         if (gui.isMouseOver(fuel.stack, recipe) && burnTime < 1) {

--- a/src/codechicken/nei/recipe/FurnaceRecipeHandler.java
+++ b/src/codechicken/nei/recipe/FurnaceRecipeHandler.java
@@ -40,6 +40,18 @@ public class FurnaceRecipeHandler extends TemplateRecipeHandler
         final PositionedStack result;
     }
 
+    @Deprecated
+    public static class FuelPair {
+        public FuelPair(ItemStack ingred, int burnTime) {
+            this.stack = new PositionedStack(ingred, 51, 42, false);
+            this.burnTime = burnTime;
+        }
+
+        public final PositionedStack stack;
+        public final int burnTime;
+    }
+
+
     @Override
     public void loadTransferRects() {
         transferRects.add(new RecipeTransferRect(new Rectangle(50, 23, 18, 18), "fuel"));

--- a/src/codechicken/nei/recipe/TemplateRecipeHandler.java
+++ b/src/codechicken/nei/recipe/TemplateRecipeHandler.java
@@ -51,9 +51,9 @@ import static codechicken.lib.gui.GuiDraw.getMousePosition;
 public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageHandler
 {
     protected static ReentrantLock lock = new ReentrantLock();
-    public static class FuelPair
+    public static class TemplateFuelPair
     {
-        public FuelPair(ItemStack ingred, int burnTime) {
+        public TemplateFuelPair(ItemStack ingred, int burnTime) {
             this.stack = new PositionedStack(ingred, 51, 42, false);
             this.burnTime = burnTime;
         }
@@ -62,7 +62,7 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
         public final int burnTime;
     }
 
-    public static List<FuelPair> afuels;
+    public static List<TemplateFuelPair> afuels;
 
     public static void findFuelsOnce() {
         // Ensure we only find fuels once, even if threaded
@@ -91,7 +91,7 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
                 if (efuels.contains(itemStack.getItem())) return null;
                 final int burnTime = TileEntityFurnace.getItemBurnTime(itemStack);
                 if (burnTime <= 0) return null;
-                return new FuelPair(itemStack.copy(), burnTime);
+                return new TemplateFuelPair(itemStack.copy(), burnTime);
             }).filter(Objects::nonNull).collect(Collectors.toList())).get();
         } catch (InterruptedException | ExecutionException e) {
             afuels = new ArrayList<>();


### PR DESCRIPTION
* Some mods (GC, for example) rely on FuelPair in FurnaceRecipeHandler so add it back as deprecated and switch to TemplateFuelPair