### PR TITLE
Fixes thread starvation issue with parallelStream in findFuels()

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -2,4 +2,4 @@ mc_version=1.7.10
 forge_version=10.13.4.1614-1.7.10
 ccl_version=1.1.3.138
 ccc_version=1.0.7.+
-mod_version=2.0.7-GTNH
+mod_version=2.0.8-GTNH

--- a/src/codechicken/nei/recipe/FurnaceRecipeHandler.java
+++ b/src/codechicken/nei/recipe/FurnaceRecipeHandler.java
@@ -70,6 +70,8 @@ public class FurnaceRecipeHandler extends TemplateRecipeHandler
 
     @Override
     public TemplateRecipeHandler newInstance() {
+        // Use the non parallel version since we might already be using the forkJoinPool and might have no threads available
+        // This will ideally have been pre-cached elsewhere and will be a NOOP
         findFuelsOnce();
         return super.newInstance();
     }

--- a/src/codechicken/nei/recipe/GuiCraftingRecipe.java
+++ b/src/codechicken/nei/recipe/GuiCraftingRecipe.java
@@ -21,7 +21,7 @@ public class GuiCraftingRecipe extends GuiRecipe
         profiler.start("recipe.concurrent.crafting");
        
         // Pre-find the fuels so we're not fighting over it
-        FuelRecipeHandler.findFuelsOnce();
+        FuelRecipeHandler.findFuelsOnceParallel();
 
         try {
             handlers = ItemList.forkJoinPool.submit(() -> craftinghandlers.parallelStream()

--- a/src/codechicken/nei/recipe/GuiUsageRecipe.java
+++ b/src/codechicken/nei/recipe/GuiUsageRecipe.java
@@ -12,12 +12,15 @@ import java.util.stream.Collectors;
 
 public class GuiUsageRecipe extends GuiRecipe
 {
-     public static boolean openRecipeGui(String inputId, Object... ingredients) {
+    public static boolean openRecipeGui(String inputId, Object... ingredients) {
         Minecraft mc = NEIClientUtils.mc();
         GuiContainer prevscreen = mc.currentScreen instanceof GuiContainer ? (GuiContainer) mc.currentScreen : null;
 
         ArrayList<IUsageHandler> handlers;
         TaskProfiler profiler = ProfilerRecipeHandler.getProfiler();
+
+        // Pre-find the fuels so we're not fighting over it
+        FuelRecipeHandler.findFuelsOnceParallel();
 
         profiler.start("recipe.concurrent.usage");
         try {


### PR DESCRIPTION
Fixes thread starvation issue with parallelStream in findFuels() being called from within another parallelStream on the same ForkJoinPool

Introduces a `findFuelsOnceParallel` that is called before the parallel recipe/usage handlers are run (which now call the non parallel version of findFuels())