### PR TITLE
Read/write lock for hiddenItems

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -2,4 +2,4 @@ mc_version=1.7.10
 forge_version=10.13.4.1614-1.7.10
 ccl_version=1.1.3.138
 ccc_version=1.0.7.+
-mod_version=2.0.10-GTNH
+mod_version=2.0.11-GTNH


### PR DESCRIPTION
Switch hiddenItems from synchronized to using a `ReentrantReadWriteLock` with a `tryLock` in order to avoid an apparent deadlock that Pandoro was experiencing. 