### PR TITLE
Always show quantity text field

### DIFF
--- a/src/codechicken/nei/ItemPanel.java
+++ b/src/codechicken/nei/ItemPanel.java
@@ -136,14 +136,7 @@ public class ItemPanel extends Widget {
     }
 
     public int getHeight(GuiContainer gui) {
-        return gui.height - 15 - y + getHightAdjustment();
-    }
-
-    public int getHightAdjustment() {
-        int hAdj = 0;
-        if (!canPerformAction("item"))
-            hAdj += 15;
-        return hAdj;
+        return gui.height - 15 - y;
     }
 
     public int getWidth(GuiContainer gui) {

--- a/src/codechicken/nei/ItemQuantityField.java
+++ b/src/codechicken/nei/ItemQuantityField.java
@@ -7,7 +7,7 @@ public class ItemQuantityField extends TextField
         centered = true;
     }
 
-    // Find a way to work this this back in
+    // Find a way to work this back in
     public boolean isValid(String string) {
         if (string.equals(""))
             return true;

--- a/src/codechicken/nei/LayoutManager.java
+++ b/src/codechicken/nei/LayoutManager.java
@@ -673,11 +673,9 @@ public class LayoutManager implements IContainerInputHandler, IContainerTooltipH
             addWidget(itemPanel);
             itemPanel.setVisible();
 
-            if (canPerformAction("item")) {
-                addWidget(more);
-                addWidget(less);
-                addWidget(quantity);
-            }
+            addWidget(more);
+            addWidget(less);
+            addWidget(quantity);
         }
 
         if (visiblity.showBookmarkPanel) {

--- a/src/codechicken/nei/TextField.java
+++ b/src/codechicken/nei/TextField.java
@@ -79,6 +79,7 @@ public abstract class TextField extends Widget
         if (!focused())
             return false;
 
+        String oldText = text();
         boolean handled = field.textboxKeyTyped(keyChar, keyID);
         if(!handled) {
             if (keyID == Keyboard.KEY_RETURN || keyID == Keyboard.KEY_NUMPADENTER || keyID == Keyboard.KEY_ESCAPE) {
@@ -88,7 +89,7 @@ public abstract class TextField extends Widget
         }
 
         if(handled) {
-            onTextChange(text());
+            onTextChange(oldText);
         }
 
         return handled;

--- a/src/codechicken/nei/ThreadOperationTimer.java
+++ b/src/codechicken/nei/ThreadOperationTimer.java
@@ -55,8 +55,11 @@ public class ThreadOperationTimer extends Thread
 
         while (thread.isAlive()) {
             synchronized (this) {
-                if (operation != null && System.currentTimeMillis() - opTime > limit)
-                    thread.stop(new TimeoutException("Operation took too long", operation));
+                if (operation != null && System.currentTimeMillis() - opTime > limit) {
+                    // Thread.stop(Throwable) is hard-deprecated and IntelliJ complains about it.
+                    //thread.stop(new TimeoutException("Operation took too long", operation));
+                    thread.stop();
+                }
             }
             try {
                 Thread.sleep(50);


### PR DESCRIPTION
Changes:
 * NEI quantity text field is now always shown
   * Also had to adjust `ItemPanel.java` height calculation to take into account the quantity text field now always being present
   * Fixes https://github.com/GTNewHorizons/NotEnoughItems/issues/133
 * Fixed a bug where manually typing a number into the quantity text field would visually update the text field contents, but was actually ignored
 * Removed call to hard-deprecated [`Thread.stop(Throwable)`](https://docs.oracle.com/javase/8/docs/api/java/lang/Thread.html#stop-java.lang.Throwable-) which was causing IntelliJ to complain