### PR TITLE
Fix height hack and add ordering config

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -2,4 +2,4 @@ mc_version=1.7.10
 forge_version=10.13.4.1614-1.7.10
 ccl_version=1.1.3.138
 ccc_version=1.0.7.+
-mod_version=2.1.13-GTNH
+mod_version=2.1.14-GTNH

--- a/resources/assets/nei/csv/handlers.csv
+++ b/resources/assets/nei/csv/handlers.csv
@@ -170,7 +170,7 @@ ic2.neiIntegration.core.recipehandler.BlockCutterRecipeHandler,IndustrialCraft 2
 ic2.neiIntegration.core.recipehandler.CentrifugeRecipeHandler,IndustrialCraft 2,IC2:blockMachine2:3,,IC2,TRUE,,,65,,5,,,,,,
 ic2.neiIntegration.core.recipehandler.CompressorRecipeHandler,IndustrialCraft 2,IC2:blockMachine:5,,IC2,TRUE,,,65,,5,,,,,,
 ic2.neiIntegration.core.recipehandler.ExtractorRecipeHandler,IndustrialCraft 2,IC2:blockMachine:4,,IC2,TRUE,,,65,,5,,,,,,
-ic2.neiIntegration.core.recipehandler.FluidCannerRecipeHandler,IndustrialCraft 2,IC2:blockMachine:6,,IC2,TRUE,,,65,,5,,,,,,
+ic2.neiIntegration.core.recipehandler.FluidCannerRecipeHandler,IndustrialCraft 2,IC2:blockMachine:6,,IC2,TRUE,,,75,,4,,,,,,
 ic2.neiIntegration.core.recipehandler.LatheRecipeHandler,IndustrialCraft 2,IC2:blockMachine3:8,,IC2,TRUE,,,65,,5,,,,,,
 ic2.neiIntegration.core.recipehandler.MaceratorRecipeHandler,IndustrialCraft 2,IC2:blockMachine:3,,IC2,TRUE,,,65,,5,,,,,,
 ic2.neiIntegration.core.recipehandler.MetalFormerRecipeHandlerCutting,IndustrialCraft 2,IC2:blockMachine2:4,,IC2,TRUE,,,55,,6,,,,,,

--- a/src/codechicken/nei/ClientHandler.java
+++ b/src/codechicken/nei/ClientHandler.java
@@ -238,10 +238,9 @@ public class ClientHandler
             return;
         }
 
-        try {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream()))) {
             NEIClientConfig.logger.info("Loading handler ordering from file {}", file);
-            BufferedReader input = new BufferedReader(new InputStreamReader(url.openStream()));
-            CSVParser csvParser = CSVFormat.EXCEL.withCommentMarker('#').parse(input);
+            CSVParser csvParser = CSVFormat.EXCEL.withCommentMarker('#').parse(reader);
             for (CSVRecord record : csvParser) {
                 final String handlerId = record.get(0);
 
@@ -253,8 +252,7 @@ public class ClientHandler
                     continue;
                 }
 
-                if (ordering != 0)
-                    NEIClientConfig.handlerOrdering.put(handlerId, ordering);
+                NEIClientConfig.handlerOrdering.put(handlerId, ordering);
             }
         } catch (Exception e) {
             NEIClientConfig.logger.info("Error parsing CSV");

--- a/src/codechicken/nei/ClientHandler.java
+++ b/src/codechicken/nei/ClientHandler.java
@@ -53,11 +53,11 @@ public class ClientHandler
         "WayofTime.alchemicalWizardry.client.nei.NEIAlchemyRecipeHandler"
     };
     private static String[] defaultHeightHackHandlers = {
+            "ic2.neiIntegration.core.recipehandler.FluidCannerRecipeHandler",
             "tconstruct.plugins.nei.RecipeHandlerAlloying",
             "tconstruct.plugins.nei.RecipeHandlerCastingBasin",
             "tconstruct.plugins.nei.RecipeHandlerCastingTable",
             "tconstruct.plugins.nei.RecipeHandlerMelting",
-            "ic2.neiIntegration.core.recipehandler.FluidCannerRecipeHandler"
     };
     private static String[] defaultHandlerOrdering = {
             "# Each line in this file should either be a comment (starts with '#') or an ordering.",
@@ -65,7 +65,7 @@ public class ClientHandler
             "# Handlers will be sorted in order of number ascending, so smaller numbers first.",
             "# Any handlers that are missing from this file will be assigned to 0.",
             "# Negative numbers are fine.",
-            "# If you delete this file, it will be regenerated with all registered handler IDs."
+            "# If you delete this file, it will be regenerated with all registered handler IDs.",
     };
     private static ClientHandler instance;
 

--- a/src/codechicken/nei/ClientHandler.java
+++ b/src/codechicken/nei/ClientHandler.java
@@ -5,6 +5,8 @@ import codechicken.core.GuiModListScroll;
 import codechicken.lib.packet.PacketCustom;
 import codechicken.nei.api.API;
 import codechicken.nei.api.ItemInfo;
+import codechicken.nei.recipe.GuiRecipeTab;
+import com.google.common.collect.Lists;
 import cpw.mods.fml.client.CustomModLoadingErrorDisplayException;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Loader;
@@ -24,12 +26,19 @@ import net.minecraft.entity.item.EntityItem;
 import net.minecraft.world.World;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.common.MinecraftForge;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.io.IOUtils;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -42,6 +51,21 @@ public class ClientHandler
 {
     private static String[] defaultSerialHandlers = {
         "WayofTime.alchemicalWizardry.client.nei.NEIAlchemyRecipeHandler"
+    };
+    private static String[] defaultHeightHackHandlers = {
+            "tconstruct.plugins.nei.RecipeHandlerAlloying",
+            "tconstruct.plugins.nei.RecipeHandlerCastingBasin",
+            "tconstruct.plugins.nei.RecipeHandlerCastingTable",
+            "tconstruct.plugins.nei.RecipeHandlerMelting",
+            "ic2.neiIntegration.core.recipehandler.FluidCannerRecipeHandler"
+    };
+    private static String[] defaultHandlerOrdering = {
+            "# Each line in this file should either be a comment (starts with '#') or an ordering.",
+            "# Ordering lines are <handler ID>,<ordering number>.",
+            "# Handlers will be sorted in order of number ascending, so smaller numbers first.",
+            "# Any handlers that are missing from this file will be assigned to 0.",
+            "# Negative numbers are fine.",
+            "# If you delete this file, it will be regenerated with all registered handler IDs."
     };
     private static ClientHandler instance;
 
@@ -128,6 +152,7 @@ public class ClientHandler
 
     public static void preInit() {
         loadSerialHandlers();
+        loadHeightHackHandlers();
         ItemInfo.preInit();
     }
     
@@ -148,7 +173,26 @@ public class ClientHandler
         } catch (IOException e) {
             NEIClientConfig.logger.error("Failed to load serial handlers from file {}", file, e);
         }
-        
+    }
+
+    public static void loadHeightHackHandlers() {
+        File file = NEIClientConfig.heightHackHandlersFile;
+        if (!file.exists()) {
+            try (FileWriter writer = new FileWriter(file)) {
+                NEIClientConfig.logger.info("Creating default height hack handlers list {}", file);
+                Collection<String> toSave = Loader.isModLoaded("dreamcraft") ? Collections.singletonList("") : Arrays.asList(defaultHeightHackHandlers);
+                IOUtils.writeLines(toSave, "\n", writer);
+            } catch (IOException e) {
+                NEIClientConfig.logger.error("Failed to save default height hack handlers list to file {}", file, e);
+            }
+        }
+
+        try (FileReader reader = new FileReader(file)) {
+            NEIClientConfig.logger.info("Loading height hack handlers from file {}", file);
+            NEIClientConfig.heightHackHandlers = new HashSet<>(IOUtils.readLines(reader));
+        } catch (IOException e) {
+            NEIClientConfig.logger.error("Failed to load height hack handlers from file {}", file, e);
+        }
     }
 
     public static void load() {
@@ -162,6 +206,60 @@ public class ClientHandler
         API.registerHighlightHandler(new DefaultHighlightHandler(), ItemInfo.Layout.HEADER);
         HUDRenderer.load();
         WorldOverlayRenderer.load();
+    }
+
+    public static void postInit() {
+        loadHandlerOrdering();
+    }
+
+    public static void loadHandlerOrdering() {
+        File file = NEIClientConfig.handlerOrderingFile;
+        if (!file.exists()) {
+            try (FileWriter writer = new FileWriter(file)) {
+                NEIClientConfig.logger.info("Creating default handler ordering CSV {}", file);
+
+                List<String> toWrite = Lists.newArrayList(defaultHandlerOrdering);
+                GuiRecipeTab.handlerMap.keySet().stream()
+                        .sorted()
+                        .forEach(handlerId -> toWrite.add(String.format("%s,0", handlerId)));
+
+                IOUtils.writeLines(toWrite, "\n", writer);
+            } catch (IOException e) {
+                NEIClientConfig.logger.error("Failed to save default handler ordering to file {}", file, e);
+            }
+        }
+
+        URL url;
+        try {
+            url = file.toURI().toURL();
+        } catch (MalformedURLException e) {
+            NEIClientConfig.logger.info("Invalid URL for handler ordering CSV.");
+            e.printStackTrace();
+            return;
+        }
+
+        try {
+            NEIClientConfig.logger.info("Loading handler ordering from file {}", file);
+            BufferedReader input = new BufferedReader(new InputStreamReader(url.openStream()));
+            CSVParser csvParser = CSVFormat.EXCEL.withCommentMarker('#').parse(input);
+            for (CSVRecord record : csvParser) {
+                final String handlerId = record.get(0);
+
+                int ordering;
+                try {
+                    ordering = Integer.parseInt(record.get(1));
+                } catch (NumberFormatException e) {
+                    NEIClientConfig.logger.error("Error parsing CSV record {}: {}", record, e);
+                    continue;
+                }
+
+                if (ordering != 0)
+                    NEIClientConfig.handlerOrdering.put(handlerId, ordering);
+            }
+        } catch (Exception e) {
+            NEIClientConfig.logger.info("Error parsing CSV");
+            e.printStackTrace();
+        }
     }
 
     @SubscribeEvent

--- a/src/codechicken/nei/NEIModContainer.java
+++ b/src/codechicken/nei/NEIModContainer.java
@@ -16,8 +16,8 @@ import cpw.mods.fml.common.MetadataCollection;
 import cpw.mods.fml.common.ModMetadata;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLInterModComms;
-import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
+import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.versioning.ArtifactVersion;
 import cpw.mods.fml.common.versioning.VersionParser;
 import cpw.mods.fml.common.versioning.VersionRange;
@@ -99,6 +99,8 @@ public class NEIModContainer extends DummyModContainer
     public void postInit(FMLPostInitializationEvent event) {
         if (CommonUtils.isClient())
             GuiRecipeTab.loadHandlerInfo();
+
+        ClientHandler.postInit();
     }
 
     @Subscribe

--- a/src/codechicken/nei/recipe/GuiCraftingRecipe.java
+++ b/src/codechicken/nei/recipe/GuiCraftingRecipe.java
@@ -8,7 +8,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
@@ -43,6 +42,8 @@ public class GuiCraftingRecipe extends GuiRecipe
 
         if (handlers.isEmpty())
             return false;
+
+        handlers.sort(NEIClientConfig.HANDLER_COMPARATOR);
 
         mc.displayGuiScreen(new GuiCraftingRecipe(prevscreen, handlers));
         return true;

--- a/src/codechicken/nei/recipe/GuiRecipeTab.java
+++ b/src/codechicken/nei/recipe/GuiRecipeTab.java
@@ -209,9 +209,8 @@ public abstract class GuiRecipeTab extends Widget {
                 return;
             }
         }
-        try {
-            BufferedReader input = new BufferedReader(new InputStreamReader(url.openStream()));
-            CSVParser csvParser = CSVFormat.EXCEL.withFirstRecordAsHeader().parse(input);
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream()))) {
+            CSVParser csvParser = CSVFormat.EXCEL.withFirstRecordAsHeader().parse(reader);
             for (CSVRecord record : csvParser) {
                 final String handler = record.get("handler");
                 final String modName = record.get("modName");

--- a/src/codechicken/nei/recipe/GuiUsageRecipe.java
+++ b/src/codechicken/nei/recipe/GuiUsageRecipe.java
@@ -8,7 +8,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiContainer;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
@@ -43,6 +42,8 @@ public class GuiUsageRecipe extends GuiRecipe
 
         if (handlers.isEmpty())
             return false;
+
+        handlers.sort(NEIClientConfig.HANDLER_COMPARATOR);
 
         mc.displayGuiScreen(new GuiUsageRecipe(prevscreen, handlers));
         return true;


### PR DESCRIPTION
Changes included in this PR:
 * Fixed the NEI height hack calculation
   * I left a bunch of comments explaining the reasoning behind the new calculation
   * Also applied the height hack to a few other methods that need it
   * Added a config to limit which handlers are affected
     * This is required because applying the hack to more methods breaks newer handlers that rely on getting an accurate `height` value
   * Tested with Tinker's smeltery handler (I used a version older than my fix to it) and IC2 fluid canner handler
     * These are included in the default handlers list. Not sure if any other handlers need to be added to it?
 * Increased IC2 fluid canner handler height so that the fluid bars no longer get overlapped (as much) by the next recipe on the page
 * Added a config to modify the handler order
   * CSV of `<handler ID>,<ordering number>`. Smaller numbers (including negatives) get sorted earlier; missing handlers are assigned to 0.
   * If the config file does not exist, it will be generated containing all registered handlers
   * I put a bunch of comments in the config file explaining how it works
 * New config file locations:
   * `minecraft/config/NEI/heighthackhandlers.cfg`
   * `minecraft/config/NEI/handlerordering.csv`
 * Addresses (4) in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8622