### PR TITLE
Make item loading timeout configurable

### DIFF
--- a/src/main/java/codechicken/nei/ItemList.java
+++ b/src/main/java/codechicken/nei/ItemList.java
@@ -185,13 +185,13 @@ public class ItemList
         @SuppressWarnings("unchecked")
         public void execute() {
             // System.out.println("Executing NEI Item Loading");
-            ThreadOperationTimer timer = getTimer(500);
+            ThreadOperationTimer timer = getTimer(NEIClientConfig.getItemLoadingTimeout());
 
             LinkedList<ItemStack> items = new LinkedList<>();
             LinkedList<ItemStack> permutations = new LinkedList<>();
             ListMultimap<Item, ItemStack> itemMap = ArrayListMultimap.create();
 
-            timer.setLimit(500);
+            timer.setLimit(NEIClientConfig.getItemLoadingTimeout());
             for (Item item : (Iterable<Item>) Item.itemRegistry) {
                 if (interrupted()) return;
 

--- a/src/main/java/codechicken/nei/NEIClientConfig.java
+++ b/src/main/java/codechicken/nei/NEIClientConfig.java
@@ -168,6 +168,8 @@ public class NEIClientConfig {
                 return isMouseScrollTransferEnabled();
             }
         });
+        
+        tag.getTag("itemLoadingTimeout").getIntValue(500);
 
         tag.getTag("command.creative").setDefaultValue("/gamemode {0} {1}");
         API.addOption(new OptionTextField("command.creative"));
@@ -445,6 +447,10 @@ public class NEIClientConfig {
     public static boolean showIDs() {
         int i = getIntSetting("inventory.itemIDs");
         return i == 2 || (i == 1 && isEnabled() && !isHidden());
+    }
+    
+    public static int getItemLoadingTimeout() {
+        return getIntSetting("itemLoadingTimeout");
     }
 
     public static void toggleBooleanSetting(String setting) {


### PR DESCRIPTION
On slower hardware (@tyrael93's), the item loading timeout of 500 ms is sometimes exceeded when loading items with a very high amount of permutations, like GT6's `gregapi.block.multitileentity.MultiTileEntityItemInternal`, which has 3189 of them.

```
[NEI Item Loading/ERROR] [NotEnoughItems/]: Removing item: gregapi.block.multitileentity.MultiTileEntityItemInternal@19f951d9 from list.
java.lang.ThreadDeath
        at java.lang.Thread.stop(Thread.java:1020) ~[?:1.8.0_275]
		at codechicken.nei.ThreadOperationTimer.run(ThreadOperationTimer.java:61) ~[ThreadOperationTimer.class:?]
```

When this happens, these items won't show up in NEI's overlay until the game is restarted, which is a major inconvenience.

This PR exposes this constant as a config option so it can be adjusted according to the user's hardware. We have found that increasing it to 5000 ms made the issue disappear, and conversely, decreasing it to 1 ms made it happen consistently. I left the default value unchanged.