### PR TITLE
Use String key for RecipeCatalyst instead of IRecipeHandler.class

### DIFF
--- a/src/main/java/codechicken/nei/api/API.java
+++ b/src/main/java/codechicken/nei/api/API.java
@@ -300,7 +300,7 @@ public class API
      * @param stack the ingredient that can craft recipes (like a furnace or crafting table)
      * @param handler the recipe category handled by the ingredient
      */
-    public static void addRecipeCatalyst(ItemStack stack, Class<? extends IRecipeHandler> handler) {
+    public static void addRecipeCatalyst(ItemStack stack, IRecipeHandler handler) {
         addRecipeCatalyst(Collections.singletonList(stack), handler);
     }
 
@@ -310,8 +310,34 @@ public class API
      * @param stacks the ingredients that can craft recipes (like a furnace or crafting table)
      * @param handler the recipe category handled by the ingredient
      */
-    public static void addRecipeCatalyst(List<ItemStack> stacks, Class<? extends IRecipeHandler> handler) {
-        RecipeCatalysts.addRecipeCatalyst(stacks, handler);
+    public static void addRecipeCatalyst(List<ItemStack> stacks, IRecipeHandler handler) {
+        String handlerID = handler.getOverlayIdentifier();
+        if (handlerID != null) {
+            addRecipeCatalyst(stacks, handler.getOverlayIdentifier());
+        }
+        else {
+            NEIClientConfig.logger.warn(String.format("failed to add recipe catalyst, implement IRecipeHandler#getOverlayIdentifier for your handler %s", handler.getClass().getName()));
+        }
+    }
+
+    /**
+     * Adds an association between an ingredient and what it can craft. (i.e. Furnace ItemStack -> Smelting and Fuel Recipes)
+     * Allows players to see what ingredient they need to craft in order to make recipes from a recipe category.
+     * @param stack the ingredient that can craft recipes (like a furnace or crafting table)
+     * @param handlerID recipe category identifier (see {@link IRecipeHandler#getOverlayIdentifier()})
+     */
+    public static void addRecipeCatalyst(ItemStack stack, String handlerID) {
+        addRecipeCatalyst(Collections.singletonList(stack), handlerID);
+    }
+
+    /**
+     * Adds an association between an ingredient and what it can craft. (i.e. Furnace ItemStack -> Smelting and Fuel Recipes)
+     * Allows players to see what ingredient they need to craft in order to make recipes from a recipe category.
+     * @param stacks the ingredients that can craft recipes (like a furnace or crafting table)
+     * @param handlerID recipe category identifier (see {@link IRecipeHandler#getOverlayIdentifier()})
+     */
+    public static void addRecipeCatalyst(List<ItemStack> stacks, String handlerID) {
+        RecipeCatalysts.addRecipeCatalyst(stacks, handlerID);
     }
 
 }

--- a/src/main/java/codechicken/nei/api/API.java
+++ b/src/main/java/codechicken/nei/api/API.java
@@ -340,4 +340,12 @@ public class API
         RecipeCatalysts.addRecipeCatalyst(stacks, handlerID);
     }
 
+    @Deprecated
+    public static void addRecipeCatalyst(ItemStack stack, Class<? extends IRecipeHandler> handler) {
+    }
+
+    @Deprecated
+    public static void addRecipeCatalyst(List<ItemStack> stacks, Class<? extends IRecipeHandler> handler) {
+    }
+
 }

--- a/src/main/java/codechicken/nei/recipe/GuiRecipe.java
+++ b/src/main/java/codechicken/nei/recipe/GuiRecipe.java
@@ -507,7 +507,7 @@ public abstract class GuiRecipe extends GuiContainer implements IGuiContainerOve
             if (result != null)
                 slotcontainer.addSlot(result, p.x, p.y);
 
-            List<PositionedStack> catalysts = RecipeCatalysts.getRecipeCatalysts(handler.getClass());
+            List<PositionedStack> catalysts = RecipeCatalysts.getRecipeCatalysts(handler);
             for (PositionedStack catalyst : catalysts) {
                 int xOffset = -GuiRecipeCatalyst.ingredientSize + 1;
                 int yOffset = BG_TOP_Y + GuiRecipeCatalyst.fullBorder;

--- a/src/main/java/codechicken/nei/recipe/GuiRecipeCatalyst.java
+++ b/src/main/java/codechicken/nei/recipe/GuiRecipeCatalyst.java
@@ -24,7 +24,7 @@ public class GuiRecipeCatalyst extends INEIGuiAdapter {
 
     public void draw() {
         if (guiRecipe == null) return;
-        int catalystsSize = RecipeCatalysts.getRecipeCatalysts(guiRecipe.getHandler().getClass()).size();
+        int catalystsSize = RecipeCatalysts.getRecipeCatalysts(guiRecipe.getHandler()).size();
         if (catalystsSize == 0) return;
 
         int availableHeight = RecipeCatalysts.getHeight();
@@ -49,7 +49,7 @@ public class GuiRecipeCatalyst extends INEIGuiAdapter {
     public boolean hideItemPanelSlot(GuiContainer gui, int x, int y, int w, int h) {
         if (!(gui instanceof GuiRecipe)) return false;
         guiRecipe = (GuiRecipe) gui;
-        int catalystsSize = RecipeCatalysts.getRecipeCatalysts(guiRecipe.getHandler().getClass()).size();
+        int catalystsSize = RecipeCatalysts.getRecipeCatalysts(guiRecipe.getHandler()).size();
         if (catalystsSize == 0) return false;
 
         int availableHeight = RecipeCatalysts.getHeight();

--- a/src/main/java/codechicken/nei/recipe/IRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/IRecipeHandler.java
@@ -90,6 +90,15 @@ public interface IRecipeHandler
      */
     public IOverlayHandler getOverlayHandler(GuiContainer gui, int recipe);
     /**
+     * Simply works with the {@link codechicken.nei.api.DefaultOverlayRenderer}
+     * If the current container has been registered with this identifier, the question mark appears and an overlay guide can be drawn.
+     *
+     * @return The overlay identifier of this recipe type.
+     */
+    public default String getOverlayIdentifier() {
+        return null;
+    }
+    /**
      * 
      * @return The number of recipes that can fit on a page in the viewer (1 or 2)
      */

--- a/src/main/java/codechicken/nei/recipe/RecipeCatalysts.java
+++ b/src/main/java/codechicken/nei/recipe/RecipeCatalysts.java
@@ -85,4 +85,23 @@ public class RecipeCatalysts {
         return NEIServerUtils.divideCeil(catalystsSize, columnCount);
     }
 
+    @Deprecated
+    public static void addRecipeCatalyst(List<ItemStack> stacks, Class<? extends IRecipeHandler> handler) {
+    }
+
+//    @Deprecated
+//    public static Map<Class<? extends IRecipeHandler>, List<PositionedStack>> getPositionedRecipeCatalystMap() {
+//        return new HashMap<>();
+//    }
+
+    @Deprecated
+    public static List<PositionedStack> getRecipeCatalysts(Class<? extends IRecipeHandler> handler) {
+        return Collections.emptyList();
+    }
+
+    @Deprecated
+    public static boolean containsCatalyst(Class<? extends IRecipeHandler> handler, ItemStack candidate) {
+        return false;
+    }
+
 }

--- a/src/main/java/codechicken/nei/recipe/RecipeCatalysts.java
+++ b/src/main/java/codechicken/nei/recipe/RecipeCatalysts.java
@@ -89,11 +89,6 @@ public class RecipeCatalysts {
     public static void addRecipeCatalyst(List<ItemStack> stacks, Class<? extends IRecipeHandler> handler) {
     }
 
-//    @Deprecated
-//    public static Map<Class<? extends IRecipeHandler>, List<PositionedStack>> getPositionedRecipeCatalystMap() {
-//        return new HashMap<>();
-//    }
-
     @Deprecated
     public static List<PositionedStack> getRecipeCatalysts(Class<? extends IRecipeHandler> handler) {
         return Collections.emptyList();

--- a/src/main/java/codechicken/nei/recipe/RecipeCatalysts.java
+++ b/src/main/java/codechicken/nei/recipe/RecipeCatalysts.java
@@ -12,39 +12,49 @@ import java.util.List;
 import java.util.Map;
 
 public class RecipeCatalysts {
-    private static final Map<Class<? extends IRecipeHandler>, List<ItemStack>> recipeCatalystMap = new HashMap<>();
-    private static Map<Class<? extends IRecipeHandler>, List<PositionedStack>> positionedRecipeCatalystMap = new HashMap<>();
+    private static final Map<String, List<ItemStack>> recipeCatalystMap = new HashMap<>();
+    private static Map<String, List<PositionedStack>> positionedRecipeCatalystMap = new HashMap<>();
     private static int heightCache;
 
-    public static void addRecipeCatalyst(List<ItemStack> stacks, Class<? extends IRecipeHandler> handler) {
-        if (recipeCatalystMap.containsKey(handler)) {
-            recipeCatalystMap.get(handler).addAll(stacks);
+    public static void addRecipeCatalyst(List<ItemStack> stacks, String handlerID) {
+        if (handlerID == null) return;
+        if (recipeCatalystMap.containsKey(handlerID)) {
+            recipeCatalystMap.get(handlerID).addAll(stacks);
         } else {
-            recipeCatalystMap.put(handler, new ArrayList<>(stacks));
+            // use ArrayList initializer to prevent UOE
+            recipeCatalystMap.put(handlerID, new ArrayList<>(stacks));
         }
     }
 
-    public static Map<Class<? extends IRecipeHandler>, List<PositionedStack>> getPositionedRecipeCatalystMap() {
+    public static Map<String, List<PositionedStack>> getPositionedRecipeCatalystMap() {
         return positionedRecipeCatalystMap;
     }
 
-    public static List<PositionedStack> getRecipeCatalysts(Class<? extends IRecipeHandler> handler) {
+    public static List<PositionedStack> getRecipeCatalysts(IRecipeHandler handler) {
+        return getRecipeCatalysts(handler.getOverlayIdentifier());
+    }
+
+    public static List<PositionedStack> getRecipeCatalysts(String handlerID) {
         if (!NEIClientConfig.areJEIStyleTabsVisible() || !NEIClientConfig.areJEIStyleRecipeCatalystsVisible()) {
             return Collections.emptyList();
         }
-        return positionedRecipeCatalystMap.getOrDefault(handler, Collections.emptyList());
+        return positionedRecipeCatalystMap.getOrDefault(handlerID, Collections.emptyList());
     }
 
-    public static boolean containsCatalyst(Class<? extends IRecipeHandler> handler, ItemStack candidate) {
-        return recipeCatalystMap.getOrDefault(handler, Collections.emptyList()).stream()
+    public static boolean containsCatalyst(IRecipeHandler handler, ItemStack candidate) {
+        return containsCatalyst(handler.getOverlayIdentifier(), candidate);
+    }
+
+    public static boolean containsCatalyst(String handlerID, ItemStack candidate) {
+        return recipeCatalystMap.getOrDefault(handlerID, Collections.emptyList()).stream()
             .anyMatch(s -> NEIServerUtils.areStacksSameType(s, candidate));
     }
 
     public static void updatePosition(int availableHeight) {
         if (availableHeight == heightCache) return;
 
-        Map<Class<? extends IRecipeHandler>, List<PositionedStack>> newMap = new HashMap<>();
-        for (Map.Entry<Class<? extends IRecipeHandler>, List<ItemStack>> entry : recipeCatalystMap.entrySet()) {
+        Map<String, List<PositionedStack>> newMap = new HashMap<>();
+        for (Map.Entry<String, List<ItemStack>> entry : recipeCatalystMap.entrySet()) {
             List<ItemStack> catalysts = entry.getValue();
             List<PositionedStack> newStacks = new ArrayList<>();
             int rowCount = getRowCount(availableHeight, catalysts.size());

--- a/src/main/java/codechicken/nei/recipe/RecipeInfo.java
+++ b/src/main/java/codechicken/nei/recipe/RecipeInfo.java
@@ -123,12 +123,10 @@ public class RecipeInfo
         API.registerRecipeHandler(new ProfilerRecipeHandler(true));
         API.registerUsageHandler(new ProfilerRecipeHandler(false));
 
-        API.addRecipeCatalyst(new ItemStack(Blocks.crafting_table), ShapedRecipeHandler.class);
-        API.addRecipeCatalyst(new ItemStack(Blocks.crafting_table), ShapelessRecipeHandler.class);
-        API.addRecipeCatalyst(new ItemStack(Blocks.crafting_table), FireworkRecipeHandler.class);
-        API.addRecipeCatalyst(new ItemStack(Blocks.furnace), FurnaceRecipeHandler.class);
-        API.addRecipeCatalyst(new ItemStack(Items.brewing_stand), BrewingRecipeHandler.class);
-        API.addRecipeCatalyst(new ItemStack(Blocks.furnace), FuelRecipeHandler.class);
+        API.addRecipeCatalyst(new ItemStack(Blocks.crafting_table), "crafting");
+        API.addRecipeCatalyst(new ItemStack(Blocks.furnace), new FurnaceRecipeHandler());
+        API.addRecipeCatalyst(new ItemStack(Items.brewing_stand), new BrewingRecipeHandler());
+        API.addRecipeCatalyst(new ItemStack(Blocks.furnace), new FuelRecipeHandler());
     }
 
 }

--- a/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
@@ -442,6 +442,7 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
      *
      * @return The overlay identifier of this recipe type.
      */
+    @Override
     public String getOverlayIdentifier() {
         return null;
     }
@@ -559,7 +560,7 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
         TemplateRecipeHandler handler = newInstance();
         if (inputId.equals("item")) {
             ItemStack candidate = (ItemStack) ingredients[0];
-            if (RecipeCatalysts.containsCatalyst(handler.getClass(), candidate)) {
+            if (RecipeCatalysts.containsCatalyst(handler, candidate)) {
                 for (RecipeTransferRect rect : transferRects) {
                     if (specifyTransferRect() == null || Objects.equals(rect.outputId, specifyTransferRect())) {
                         handler.loadCraftingRecipes(rect.outputId, rect.results);


### PR DESCRIPTION
This will allow:
- registering catalysts for GT recipe maps. They use in-line handler, so there is no way to distinguish their recipes by handler class.
- sharing catalysts across categories. e.g. "crafting" handlerID is used in not only vanilla recipes but also other mods, like AE2 and BM. `addRecipeCatalyst(stack, "crafting")` will allow automatically registering to those categories.

And please bump up version, to specify it in other mods.