### PR TITLE
Made handler tab names customizable

### DIFF
--- a/src/main/java/codechicken/nei/recipe/GuiRecipeTab.java
+++ b/src/main/java/codechicken/nei/recipe/GuiRecipeTab.java
@@ -66,7 +66,7 @@ public abstract class GuiRecipeTab extends Widget {
         this.selected = false;
 
         if(handler instanceof TemplateRecipeHandler) {
-            handlerID = (((TemplateRecipeHandler)handler).getOverlayIdentifier());
+            handlerID = handler.getOverlayIdentifier();
         } else {
             handlerID = null;
         }
@@ -162,7 +162,7 @@ public abstract class GuiRecipeTab extends Widget {
         final String handlerID;
 
         if (handler instanceof TemplateRecipeHandler) {
-            handlerID = ((TemplateRecipeHandler) handler).getOverlayIdentifier();
+            handlerID = handler.getOverlayIdentifier();
         } else {
             handlerID = null;
         }
@@ -272,9 +272,6 @@ public abstract class GuiRecipeTab extends Widget {
                 handlerMap.put(handler, info);
                 NEIClientConfig.logger.info("Loaded " + handler);
             }
-        } catch (IOException e) {
-            NEIClientConfig.logger.info("Error parsing CSV");
-            e.printStackTrace();
         } catch (Exception e) {
             NEIClientConfig.logger.info("Error parsing CSV");
             e.printStackTrace();

--- a/src/main/java/codechicken/nei/recipe/GuiRecipeTab.java
+++ b/src/main/java/codechicken/nei/recipe/GuiRecipeTab.java
@@ -130,7 +130,7 @@ public abstract class GuiRecipeTab extends Widget {
     }
 
     public void addTooltips(List<String> tooltip) {
-        tooltip.add(handler.getRecipeName().trim());
+        tooltip.add(handler.getRecipeTabName().trim());
         
         String handlerMod = getHandlerMod(handlerName, handlerID);
         tooltip.add(EnumChatFormatting.BLUE + handlerMod);

--- a/src/main/java/codechicken/nei/recipe/IRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/IRecipeHandler.java
@@ -29,7 +29,17 @@ public interface IRecipeHandler
      * @return The name of this inventory. 
      * To be displayed at the top of the viewing container.
      */
-    public String getRecipeName();
+
+    /**
+     * For legacy compatibility reasons, this method's default implementation returns the recipe name. This is also the expected behavior
+     *
+     * @return The name of this inventory.
+     * To be displayed in the tooltip in the tab at the top of the viewing container.
+     */
+    default String getRecipeTabName() {
+        return getRecipeName();
+    }
+
     /**
      * 
      * @return The number of recipes that this handler contains.

--- a/src/main/java/codechicken/nei/recipe/IRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/IRecipeHandler.java
@@ -29,6 +29,7 @@ public interface IRecipeHandler
      * @return The name of this inventory. 
      * To be displayed at the top of the viewing container.
      */
+    String getRecipeName();
 
     /**
      * For legacy compatibility reasons, this method's default implementation returns the recipe name. This is also the expected behavior
@@ -44,41 +45,39 @@ public interface IRecipeHandler
      * 
      * @return The number of recipes that this handler contains.
      */
-    public int numRecipes();
+    int numRecipes();
     /**
      * Draw the background of this recipe handler (basically the slot layout image).
-     * @param gui A GuiManager for drawing functions.
      * @param recipe The recipe index to draw at this position.
      */
-    public void drawBackground(int recipe);
+    void drawBackground(int recipe);
     /**
      * Draw the foreground of this recipe handler (for things like progress bars).
-     * @param gui A GuiManager for drawing functions.
      * @param recipe The recipe index to draw at this position.
      */
-    public void drawForeground(int recipe);
+    void drawForeground(int recipe);
     /**
      * 
      * @param recipe The recipe index to get items for.
      * @return A list of the ingredient {@link PositionedStack}s in this recipe relative to the top left corner of your recipe drawing space.
      */
-    public List<PositionedStack> getIngredientStacks(int recipe);
+    List<PositionedStack> getIngredientStacks(int recipe);
     /**
      * 
-     * @param recipe The recipe index to get items for.
+     * @param recipetype The recipe index to get items for.
      * @return A list of the other {@link PositionedStack}s in this recipe relative to the top left corner of your recipe drawing space. For example fuel in furnaces.
      */
-    public List<PositionedStack> getOtherStacks(int recipetype);
+    List<PositionedStack> getOtherStacks(int recipetype);
     /**
      * 
      * @param recipe The recipe index to get the result for.
      * @return The recipe result {@link PositionedStack} relative to the top left corner of your recipe drawing space.
      */
-    public PositionedStack getResultStack(int recipe);
+    PositionedStack getResultStack(int recipe);
     /**
      * A tick function called for updating progress bars and cycling damage items.
      */
-    public void onUpdate();
+    void onUpdate();
     /**
      * 
      * @param recipe The recipe index to check for.
@@ -86,33 +85,33 @@ public interface IRecipeHandler
      * @param container The container of the GUI.
      * @return true if this recipe can render an overlay for the specified type of inventory GUI.
      */
-    public boolean hasOverlay(GuiContainer gui, Container container, int recipe);    
+    boolean hasOverlay(GuiContainer gui, Container container, int recipe);
     /**
      * 
      * @param recipe The recipe index to get the overlay renderer for.
      * @return An instance of {@link IRecipeOverlayRenderer} to be used for rendering the overlay of this specific recipe.
      */
-    public IRecipeOverlayRenderer getOverlayRenderer(GuiContainer gui, int recipe);
+    IRecipeOverlayRenderer getOverlayRenderer(GuiContainer gui, int recipe);
     /**
      * 
      * @param recipe The recipe index to get the overlay renderer for.
      * @return An instance of {@link IOverlayHandler} to be used for rendering the overlay of this specific recipe.
      */
-    public IOverlayHandler getOverlayHandler(GuiContainer gui, int recipe);
+    IOverlayHandler getOverlayHandler(GuiContainer gui, int recipe);
     /**
      * Simply works with the {@link codechicken.nei.api.DefaultOverlayRenderer}
      * If the current container has been registered with this identifier, the question mark appears and an overlay guide can be drawn.
      *
      * @return The overlay identifier of this recipe type.
      */
-    public default String getOverlayIdentifier() {
+    default String getOverlayIdentifier() {
         return null;
     }
     /**
      * 
      * @return The number of recipes that can fit on a page in the viewer (1 or 2)
      */
-    public int recipiesPerPage();
+    int recipiesPerPage();
     /**
      * 
      * @param gui An instance of the currentscreen
@@ -120,16 +119,16 @@ public interface IRecipeHandler
      * @param recipe The recipe index being handled
      * @return The modified tooltip. DO NOT return null
      */
-    public List<String> handleTooltip(GuiRecipe gui, List<String> currenttip, int recipe);
+    List<String> handleTooltip(GuiRecipe gui, List<String> currenttip, int recipe);
     /**
      * 
      * @param gui An instance of the currentscreen
-     * @param The itemstack currently under the mouse
-     * @param The current tooltip, will contain item name and info
+     * @param stack The itemstack currently under the mouse
+     * @param currenttip The current tooltip, will contain item name and info
      * @param recipe The recipe index being handled
      * @return The modified tooltip. DO NOT return null
      */
-    public List<String> handleItemTooltip(GuiRecipe gui, ItemStack stack, List<String> currenttip, int recipe);
+    List<String> handleItemTooltip(GuiRecipe gui, ItemStack stack, List<String> currenttip, int recipe);
     
     /**
      * 
@@ -138,7 +137,7 @@ public interface IRecipeHandler
      * @param keyCode The KeyCode as defined in {@link Keyboard}
      * @return true to terminate further processing of this event.
      */
-    public boolean keyTyped(GuiRecipe gui, char keyChar, int keyCode, int recipe);
+    boolean keyTyped(GuiRecipe gui, char keyChar, int keyCode, int recipe);
 
     /**
      * 
@@ -146,7 +145,7 @@ public interface IRecipeHandler
      * @param button The button index being pressed, {0 = Left Click, 1 = Right Click, 2 = Middle Click}
      * @return true to terminate further processing of this event.
      */
-    public boolean mouseClicked(GuiRecipe gui, int button, int recipe);
+    boolean mouseClicked(GuiRecipe gui, int button, int recipe);
 
     /**
      * For legacy compatibility reasons, this method has a do-nothing default implementation.


### PR DESCRIPTION
Allow Recipe Handlers to have a different tab name than what's displayed on top of the UI.
Also some code & Javadoc cleanup.

For use in a GT5U  PR