### PR TITLE
Ignore "drop key" presses in slot click handler.

### DIFF
--- a/src/main/java/codechicken/nei/NEIController.java
+++ b/src/main/java/codechicken/nei/NEIController.java
@@ -137,6 +137,7 @@ public class NEIController implements IContainerSlotClickHandler, IContainerInpu
         }
 
         if (NEIClientUtils.controlKey()
+                && modifier != 4//Drop key pressed: net.minecraft.client.gui.inventory.GuiContainer.keyTyped
                 && slot != null && slot.getStack() != null
                 && slot.isItemValid(slot.getStack())) {
             NEIClientUtils.cheatItem(slot.getStack(), button, 1);


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/9605

PS. Minecraft code is weird. `modifier=4` means "drop key pressed" and `button=1` means ctrl key pressed. Feels backwards.