### PR TITLE
Move fuel info from tooltip to foreground

### DIFF
--- a/src/main/java/codechicken/nei/recipe/FuelRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/FuelRecipeHandler.java
@@ -2,9 +2,11 @@ package codechicken.nei.recipe;
 
 import codechicken.nei.NEIClientUtils;
 import codechicken.nei.PositionedStack;
+import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.FurnaceRecipes;
 
+import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -87,26 +89,13 @@ public class FuelRecipeHandler extends FurnaceRecipeHandler
     }
 
     @Override
-    public List<String> handleItemTooltip(GuiRecipe gui, ItemStack stack, List<String> currenttip, int recipe) {
+    public void drawExtras(int recipe) {
+        super.drawExtras(recipe);
         CachedFuelRecipe crecipe = (CachedFuelRecipe) arecipes.get(recipe);
         FuelPair fuel = crecipe.fuel;
-        float burnTime = fuel.burnTime / 200F;
-
-        if (gui.isMouseOver(fuel.stack, recipe) && burnTime < 1) {
-            burnTime = 1F / burnTime;
-            String s_time = Float.toString(burnTime);
-            if (burnTime == Math.round(burnTime))
-                s_time = Integer.toString((int) burnTime);
-
-            currenttip.add(translate("recipe.fuel.required", s_time));
-        } else if ((gui.isMouseOver(crecipe.getResult(), recipe) || gui.isMouseOver(crecipe.getIngredient(), recipe)) && burnTime > 1) {
-            String s_time = Float.toString(burnTime);
-            if (burnTime == Math.round(burnTime))
-                s_time = Integer.toString((int) burnTime);
-
-            currenttip.add(translate("recipe.fuel." + (gui.isMouseOver(crecipe.getResult(), recipe) ? "produced" : "processed"), s_time));
-        }
-
-        return currenttip;
+        NumberFormat numberInstance = NumberFormat.getNumberInstance();
+        numberInstance.setMaximumFractionDigits(2);
+        String smeltCount = numberInstance.format(fuel.burnTime / 200f);
+        Minecraft.getMinecraft().fontRenderer.drawString(translate("recipe.fuel.smeltCount", smeltCount), 73, 51, 0xFF000000);
     }
 }

--- a/src/main/resources/assets/nei/lang/en_US.lang
+++ b/src/main/resources/assets/nei/lang/en_US.lang
@@ -231,8 +231,12 @@ nei.recipe.shaped=Shaped Crafting
 nei.recipe.shapeless=Shapeless Crafting
 nei.recipe.furnace=Smelting
 nei.recipe.fuel=Fuel
+nei.recipe.fuel.smeltCount=Smelts %s items
+# Deprecated
 nei.recipe.fuel.required=%s required
+# Deprecated
 nei.recipe.fuel.processed=%s processed
+# Deprecated
 nei.recipe.fuel.produced=%s produced
 nei.recipe.firework=Fireworks
 nei.recipe.firework.tooltip0=Dyes add colours to the charges


### PR DESCRIPTION
One player in UHV didn't know they were on tooltip.

![2022-02-05_02 43 54](https://user-images.githubusercontent.com/40035906/152577581-98b1df53-b49c-4e20-aa74-10cb75ec101b.png)
