### PR TITLE
Add new chunk overlay mode for gregtech ore regions

### DIFF
--- a/src/main/java/codechicken/nei/NEIModContainer.java
+++ b/src/main/java/codechicken/nei/NEIModContainer.java
@@ -34,7 +34,7 @@ public class NEIModContainer extends DummyModContainer
 {
     public static LinkedList<IConfigureNEI> plugins = new LinkedList<>();
 
-    private static boolean gregTechLoaded;
+    private static boolean gregTech5Loaded;
 
     public NEIModContainer() {
         super(getModMetadata());
@@ -49,8 +49,8 @@ public class NEIModContainer extends DummyModContainer
         return modMetadata;
     }
 
-    public static boolean isGregTechLoaded() {
-        return gregTechLoaded;
+    public static boolean isGT5Loaded() {
+        return gregTech5Loaded;
     }
 
     @Override
@@ -99,7 +99,7 @@ public class NEIModContainer extends DummyModContainer
 
     @Subscribe
     public void preInit(FMLPreInitializationEvent event) {
-        gregTechLoaded = Loader.isModLoaded("gregtech");
+        gregTech5Loaded = Loader.isModLoaded("gregtech") && !Loader.isModLoaded("gregapi_post");
         if (CommonUtils.isClient())
             ClientHandler.preInit();
     }

--- a/src/main/java/codechicken/nei/NEIModContainer.java
+++ b/src/main/java/codechicken/nei/NEIModContainer.java
@@ -13,6 +13,7 @@ import cpw.mods.fml.client.FMLFileResourcePack;
 import cpw.mods.fml.client.FMLFolderResourcePack;
 import cpw.mods.fml.common.DummyModContainer;
 import cpw.mods.fml.common.LoadController;
+import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.ModMetadata;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLInterModComms;
@@ -33,6 +34,8 @@ public class NEIModContainer extends DummyModContainer
 {
     public static LinkedList<IConfigureNEI> plugins = new LinkedList<>();
 
+    private static boolean gregTechLoaded;
+
     public NEIModContainer() {
         super(getModMetadata());
         loadMetadata();
@@ -44,6 +47,10 @@ public class NEIModContainer extends DummyModContainer
         modMetadata.modId = "GRADLETOKEN_MODID";
         modMetadata.version = "GRADLETOKEN_VERSION";
         return modMetadata;
+    }
+
+    public static boolean isGregTechLoaded() {
+        return gregTechLoaded;
     }
 
     @Override
@@ -92,6 +99,7 @@ public class NEIModContainer extends DummyModContainer
 
     @Subscribe
     public void preInit(FMLPreInitializationEvent event) {
+        gregTechLoaded = Loader.isModLoaded("gregtech");
         if (CommonUtils.isClient())
             ClientHandler.preInit();
     }

--- a/src/main/java/codechicken/nei/WorldOverlayRenderer.java
+++ b/src/main/java/codechicken/nei/WorldOverlayRenderer.java
@@ -33,7 +33,7 @@ public class WorldOverlayRenderer implements IKeyStateTracker
         if (KeyManager.keyStates.get("world.moboverlay").down)
             mobOverlay = (mobOverlay + 1) % 2;
         if (KeyManager.keyStates.get("world.chunkoverlay").down)
-            chunkOverlay = (chunkOverlay + 1) % 3;
+            chunkOverlay = (chunkOverlay + 1) % (NEIModContainer.isGregTechLoaded() ? 4 : 3);
     }
 
     public static void render(float frame) {
@@ -172,40 +172,87 @@ public class WorldOverlayRenderer implements IKeyStateTracker
                     GL11.glVertex3d(x1, y2, z1);
                 }
 
-                if (chunkOverlay == 2 && cx == 0 && cz == 0) {
-                    dy = 32;
-                    y1 = Math.floor(entity.posY - dy / 2);
-                    y2 = y1 + dy;
-                    if (y1 < 0) {
-                        y1 = 0;
-                        y2 = dy;
-                    }
+                if (cx == 0 && cz == 0) {
+                    if (chunkOverlay == 2) {
+                        dy = 32;
+                        y1 = Math.floor(entity.posY - dy / 2);
+                        y2 = y1 + dy;
+                        if (y1 < 0) {
+                            y1 = 0;
+                            y2 = dy;
+                        }
 
-                    if (y1 > entity.worldObj.getHeight()) {
-                        y2 = entity.worldObj.getHeight();
-                        y1 = y2 - dy;
-                    }
+                        if (y1 > entity.worldObj.getHeight()) {
+                            y2 = entity.worldObj.getHeight();
+                            y1 = y2 - dy;
+                        }
 
-                    GL11.glColor4d(0, 0.9, 0, 0.4);
-                    for (double y = (int) y1; y <= y2; y++) {
-                        GL11.glVertex3d(x2, y, z1);
-                        GL11.glVertex3d(x2, y, z2);
-                        GL11.glVertex3d(x1, y, z1);
-                        GL11.glVertex3d(x1, y, z2);
-                        GL11.glVertex3d(x1, y, z2);
-                        GL11.glVertex3d(x2, y, z2);
-                        GL11.glVertex3d(x1, y, z1);
-                        GL11.glVertex3d(x2, y, z1);
-                    }
-                    for (double h = 1; h <= 15; h++) {
-                        GL11.glVertex3d(x1 + h, y1, z1);
-                        GL11.glVertex3d(x1 + h, y2, z1);
-                        GL11.glVertex3d(x1 + h, y1, z2);
-                        GL11.glVertex3d(x1 + h, y2, z2);
-                        GL11.glVertex3d(x1, y1, z1 + h);
-                        GL11.glVertex3d(x1, y2, z1 + h);
-                        GL11.glVertex3d(x2, y1, z1 + h);
-                        GL11.glVertex3d(x2, y2, z1 + h);
+                        GL11.glColor4d(0, 0.9, 0, 0.4);
+                        for (double y = (int) y1; y <= y2; y++) {
+                            GL11.glVertex3d(x2, y, z1);
+                            GL11.glVertex3d(x2, y, z2);
+                            GL11.glVertex3d(x1, y, z1);
+                            GL11.glVertex3d(x1, y, z2);
+                            GL11.glVertex3d(x1, y, z2);
+                            GL11.glVertex3d(x2, y, z2);
+                            GL11.glVertex3d(x1, y, z1);
+                            GL11.glVertex3d(x2, y, z1);
+                        }
+                        for (double h = 1; h <= 15; h++) {
+                            GL11.glVertex3d(x1 + h, y1, z1);
+                            GL11.glVertex3d(x1 + h, y2, z1);
+                            GL11.glVertex3d(x1 + h, y1, z2);
+                            GL11.glVertex3d(x1 + h, y2, z2);
+                            GL11.glVertex3d(x1, y1, z1 + h);
+                            GL11.glVertex3d(x1, y2, z1 + h);
+                            GL11.glVertex3d(x2, y1, z1 + h);
+                            GL11.glVertex3d(x2, y2, z1 + h);
+                        }
+                    } else if (chunkOverlay == 3) {
+                        int gx1 = ((entity.chunkCoordX < 0 ? entity.chunkCoordX - 2 : entity.chunkCoordX) / 3 * 3) << 4;
+                        int gz1 = ((entity.chunkCoordZ < 0 ? entity.chunkCoordZ - 2 : entity.chunkCoordZ) / 3 * 3) << 4;
+                        int gx2 = gx1 + 48;
+                        int gz2 = gz1 + 48;
+
+                        GL11.glColor4d(0, 0.9, 0, 0.4);
+                        for (double y = (int) y1; y <= y2; y++) {
+                            GL11.glVertex3d(gx2, y, gz1);
+                            GL11.glVertex3d(gx2, y, gz2);
+                            GL11.glVertex3d(gx1, y, gz1);
+                            GL11.glVertex3d(gx1, y, gz2);
+                            GL11.glVertex3d(gx1, y, gz2);
+                            GL11.glVertex3d(gx2, y, gz2);
+                            GL11.glVertex3d(gx1, y, gz1);
+                            GL11.glVertex3d(gx2, y, gz1);
+                        }
+                        for (double h = 4; h <= 44; h += 4) {
+                            if (h % 16 == 0) {
+                                continue;
+                            }
+                            GL11.glVertex3d(gx1 + h, y1, gz1);
+                            GL11.glVertex3d(gx1 + h, y2, gz1);
+                            GL11.glVertex3d(gx1 + h, y1, gz2);
+                            GL11.glVertex3d(gx1 + h, y2, gz2);
+                            GL11.glVertex3d(gx1, y1, gz1 + h);
+                            GL11.glVertex3d(gx1, y2, gz1 + h);
+                            GL11.glVertex3d(gx2, y1, gz1 + h);
+                            GL11.glVertex3d(gx2, y2, gz1 + h);
+                        }
+
+                        GL11.glColor4d(0, 0, 0.9, 0.4);
+                        gx1 += 23;
+                        gz1 += 23;
+                        gx2 = gx1 + 1;
+                        gz2 = gz1 + 1;
+
+                        GL11.glVertex3d(gx1, y1, gz1);
+                        GL11.glVertex3d(gx1, y2, gz1);
+                        GL11.glVertex3d(gx2, y1, gz1);
+                        GL11.glVertex3d(gx2, y2, gz1);
+                        GL11.glVertex3d(gx1, y1, gz2);
+                        GL11.glVertex3d(gx1, y2, gz2);
+                        GL11.glVertex3d(gx2, y1, gz2);
+                        GL11.glVertex3d(gx2, y2, gz2);
                     }
                 }
             }

--- a/src/main/java/codechicken/nei/WorldOverlayRenderer.java
+++ b/src/main/java/codechicken/nei/WorldOverlayRenderer.java
@@ -33,7 +33,7 @@ public class WorldOverlayRenderer implements IKeyStateTracker
         if (KeyManager.keyStates.get("world.moboverlay").down)
             mobOverlay = (mobOverlay + 1) % 2;
         if (KeyManager.keyStates.get("world.chunkoverlay").down)
-            chunkOverlay = (chunkOverlay + 1) % (NEIModContainer.isGregTechLoaded() ? 4 : 3);
+            chunkOverlay = (chunkOverlay + 1) % (NEIModContainer.isGT5Loaded() ? 4 : 3);
     }
 
     public static void render(float frame) {

--- a/src/main/java/codechicken/nei/WorldOverlayRenderer.java
+++ b/src/main/java/codechicken/nei/WorldOverlayRenderer.java
@@ -209,8 +209,14 @@ public class WorldOverlayRenderer implements IKeyStateTracker
                             GL11.glVertex3d(x2, y2, z1 + h);
                         }
                     } else if (chunkOverlay == 3) {
-                        int gx1 = ((entity.chunkCoordX < 0 ? entity.chunkCoordX - 2 : entity.chunkCoordX) / 3 * 3) << 4;
-                        int gz1 = ((entity.chunkCoordZ < 0 ? entity.chunkCoordZ - 2 : entity.chunkCoordZ) / 3 * 3) << 4;
+                        int gx1 = ((entity.chunkCoordX < 0 ? entity.chunkCoordX - 3 : entity.chunkCoordX) / 3 * 3) << 4;
+                        int gz1 = ((entity.chunkCoordZ < 0 ? entity.chunkCoordZ - 3 : entity.chunkCoordZ) / 3 * 3) << 4;
+                        if (entity.chunkCoordX < 0) {
+                            gx1 += 16;
+                        }
+                        if (entity.chunkCoordZ < 0) {
+                            gz1 += 16;
+                        }
                         int gx2 = gx1 + 48;
                         int gz2 = gz1 + 48;
 


### PR DESCRIPTION
New F9 mode that shows 3x3 chunk regions and central blocks in central chunks.
Works only if GregTech is loaded!

![image](https://user-images.githubusercontent.com/14280202/152657228-fb5b3f63-1284-4a3b-9c27-5c020701c09a.png)
![image](https://user-images.githubusercontent.com/14280202/152657233-da1b6db9-86c8-4d29-bd31-875e0bc3322c.png)
![image](https://user-images.githubusercontent.com/14280202/152657249-590d91f1-f28f-4fa4-b968-a533171e6a5a.png)





