### PR TITLE
super unlikely NPE fix

### DIFF
--- a/addon.gradle
+++ b/addon.gradle
@@ -1,0 +1,3 @@
+compileJava {
+    options.encoding = "UTF-8"
+}

--- a/src/main/java/codechicken/nei/LayoutManager.java
+++ b/src/main/java/codechicken/nei/LayoutManager.java
@@ -77,11 +77,11 @@ public class LayoutManager implements IContainerInputHandler, IContainerTooltipH
     /**
      * Sorted bottom first
      */
-    private static TreeSet<Widget> drawWidgets;
+    private static final TreeSet<Widget> drawWidgets = new TreeSet<>(new WidgetZOrder(false));
     /**
      * Sorted top first
      */
-    private static TreeSet<Widget> controlWidgets;
+    private static final TreeSet<Widget> controlWidgets = new TreeSet<>(new WidgetZOrder(true));
 
     public static ItemPanel itemPanel;
     public static BookmarkPanel bookmarkPanel;
@@ -669,8 +669,8 @@ public class LayoutManager implements IContainerInputHandler, IContainerTooltipH
     }
 
     public static void updateWidgetVisiblities(GuiContainer gui, VisiblityData visiblity) {
-        drawWidgets = new TreeSet<>(new WidgetZOrder(false));
-        controlWidgets = new TreeSet<>(new WidgetZOrder(true));
+        drawWidgets.clear();
+        controlWidgets.clear();
 
         if (!visiblity.showNEI)
             return;


### PR DESCRIPTION
but it does happen, and the crash report ends up in my inbox.

The addon.gradle ensure unicode stuff ("✕") in PresetsWidget doesn't blow up during compile.

<details>
<summary>crash report</summary>
---- Minecraft Crash Report ----
// Why did you do that?

Time: 3/4/22 11:51 PM
Description: Ticking screen

java.lang.NullPointerException: Ticking screen
	at codechicken.nei.LayoutManager.guiTick(LayoutManager.java:759)
	at codechicken.nei.guihook.GuiContainerManager.updateScreen(GuiContainerManager.java:335)
	at net.minecraft.client.gui.inventory.GuiContainer.func_73876_c(GuiContainer.java:698)
	at net.p455w0rd.wirelesscraftingterminal.client.gui.GuiWirelessCraftingTerminal.func_73876_c(GuiWirelessCraftingTerminal.java:453)
	at net.minecraft.client.Minecraft.func_71407_l(Minecraft.java:1661)
	at net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:973)
	at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:898)
	at net.minecraft.client.main.Main.main(SourceFile:148)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at org.multimc.onesix.OneSixLauncher.launchWithMainClass(OneSixLauncher.java:196)
	at org.multimc.onesix.OneSixLauncher.launch(OneSixLauncher.java:231)
	at org.multimc.EntryPoint.listen(EntryPoint.java:143)
	at org.multimc.EntryPoint.main(EntryPoint.java:34)


A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------

-- Head --
Stacktrace:
	at codechicken.nei.LayoutManager.guiTick(LayoutManager.java:759)
	at codechicken.nei.guihook.GuiContainerManager.updateScreen(GuiContainerManager.java:335)
	at net.minecraft.client.gui.inventory.GuiContainer.func_73876_c(GuiContainer.java:698)
	at net.p455w0rd.wirelesscraftingterminal.client.gui.GuiWirelessCraftingTerminal.func_73876_c(GuiWirelessCraftingTerminal.java:453)
	at net.minecraft.client.Minecraft.func_71407_l(Minecraft.java:1661)

-- Affected screen --
Details:
	Screen name: net.p455w0rd.wirelesscraftingterminal.client.gui.GuiWirelessCraftingTerminal

-- Affected level --
Details:
	Level name: MpServer
	All players: 1 total; [GCEntityClientPlayerMP['LengPaoLaJiao'/979, l='MpServer', x=15.78, y=20.62, z=5.24]]
	Chunk stats: MultiplayerChunkCache: 625, 625
	Level seed: 0
	Level generator: ID 04 - RWG, ver 0. Features enabled: false
	Level generator options: 
	Level spawn location: World: (-261,64,-244), Chunk: (at 11,4,12 in -17,-16; contains blocks -272,0,-256 to -257,255,-241), Region: (-1,-1; contains chunks -32,-32 to -1,-1, blocks -512,0,-512 to -1,255,-1)
	Level time: 257471703 game time, 6000 day time
	Level dimension: 0
	Level storage version: 0x00000 - Unknown?
	Level weather: Rain time: 0 (now: false), thunder time: 0 (now: false)
	Level game mode: Game mode: survival (ID 0). Hardcore: false. Cheats: false
	Forced entities: 25 total; [EntityAspectOrb['Aspect Orb'/126217, l='MpServer', x=21.63, y=6.06, z=-24.19], EntityXPOrb['Experience Orb'/77461, l='MpServer', x=20.19, y=7.25, z=-25.19], EntityAspectOrb['Aspect Orb'/126635, l='MpServer', x=22.25, y=6.06, z=-24.19], EntityAspectOrb['Aspect Orb'/126634, l='MpServer', x=21.06, y=6.06, z=-24.25], EntityAspectOrb['Aspect Orb'/126637, l='MpServer', x=24.28, y=6.06, z=-24.22], EntityAspectOrb['Aspect Orb'/126636, l='MpServer', x=24.06, y=6.06, z=-24.38], EntityStaballoyConstruct['Staballoy Construct'/125743, l='MpServer', x=19.52, y=6.01, z=-26.64], EntityStaballoyConstruct['Staballoy Construct'/125744, l='MpServer', x=20.70, y=6.03, z=-24.70], EntityCinderBlaze['Cinder'/960, l='MpServer', x=19.53, y=10.00, z=-24.53], EntityStaballoyConstruct['Staballoy Construct'/118081, l='MpServer', x=20.64, y=6.03, z=-24.70], EntityStaballoyConstruct['Staballoy Construct'/118080, l='MpServer', x=19.70, y=6.03, z=-25.70], EntityXPOrb['Experience Orb'/76229, l='MpServer', x=20.19, y=7.25, z=-24.69], EntityXPOrb['Experience Orb'/76231, l='MpServer', x=20.19, y=7.25, z=-25.19], EntityXPOrb['Experience Orb'/97873, l='MpServer', x=20.19, y=7.25, z=-25.19], EntityXPOrb['Experience Orb'/131538, l='MpServer', x=20.75, y=6.25, z=-26.05], EntityXPOrb['Experience Orb'/97872, l='MpServer', x=20.19, y=7.25, z=-25.19], EntityXPOrb['Experience Orb'/131539, l='MpServer', x=20.98, y=6.24, z=-25.26], EntityXPOrb['Experience Orb'/3410, l='MpServer', x=20.19, y=7.25, z=-25.19], EntityXPOrb['Experience Orb'/3413, l='MpServer', x=20.19, y=7.25, z=-25.19], GCEntityClientPlayerMP['LengPaoLaJiao'/979, l='MpServer', x=15.78, y=20.62, z=5.24], EntityChicken['Chicken'/730, l='MpServer', x=53.44, y=46.00, z=-62.47], EntityChicken['Chicken'/733, l='MpServer', x=-60.72, y=19.00, z=-62.47], EntityChicken['Chicken'/736, l='MpServer', x=78.47, y=45.00, z=2.31], EntityXPOrb['Experience Orb'/76131, l='MpServer', x=20.19, y=7.25, z=-25.19], EntityChicken['Chicken'/764, l='MpServer', x=65.59, y=45.00, z=-62.47]]
	Retry entities: 0 total; []
	Server brand: fml,forge
	Server type: Integrated singleplayer server
Stacktrace:
	at net.minecraft.client.Minecraft.func_71396_d(Minecraft.java:2444)
	at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:919)
	at net.minecraft.client.main.Main.main(SourceFile:148)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at org.multimc.onesix.OneSixLauncher.launchWithMainClass(OneSixLauncher.java:196)
	at org.multimc.onesix.OneSixLauncher.launch(OneSixLauncher.java:231)
	at org.multimc.EntryPoint.listen(EntryPoint.java:143)
	at org.multimc.EntryPoint.main(EntryPoint.java:34)

-- System Details --
Details:
	Minecraft Version: 1.7.10
	Operating System: Windows 10 (amd64) version 10.0
	Java Version: 1.8.0_241, Oracle Corporation
	Java VM Version: Java HotSpot(TM) 64-Bit Server VM (mixed mode), Oracle Corporation
	Memory: 9164717336 bytes (8740 MB) / 15621160960 bytes (14897 MB) up to 15621160960 bytes (14897 MB)
	JVM Flags: 3 total; -XX:HeapDumpPath=MojangTricksIntelDriversForPerformance_javaw.exe_minecraft.exe.heapdump -Xms8192m -Xmx16024m
	AABB Pool Size: 0 (0 bytes; 0 MB) allocated, 0 (0 bytes; 0 MB) used
	IntCache: cache: 0, tcache: 0, allocated: 14, tallocated: 21
	FML: MCP v9.05 FML v7.10.99.99 Minecraft Forge 10.13.4.1614 283 mods loaded, 283 mods active
	States: 'U' = Unloaded 'L' = Loaded 'C' = Constructed 'H' = Pre-initialized 'I' = Initialized 'J' = Post-initialized 'A' = Available 'D' = Disabled 'E' = Errored
	UCHIJAAAAA	mcp{9.05} [Minecraft Coder Pack] (minecraft.jar) 
	UCHIJAAAAA	FML{7.10.99.99} [Forge Mod Loader] (forge-1.7.10-10.13.4.1614-1.7.10-universal.jar) 
	UCHIJAAAAA	Forge{10.13.4.1614} [Minecraft Forge] (forge-1.7.10-10.13.4.1614-1.7.10-universal.jar) 
	UCHIJAAAAA	appliedenergistics2-core{rv3-beta-80-GTNH-pre} [Applied Energistics 2 Core] (minecraft.jar) 
	UCHIJAAAAA	Aroma1997Core{1.0.2.16} [Aroma1997Core] (Aroma1997Core-1.7.10-1.0.2.16.jar) 
	UCHIJAAAAA	CodeChickenCore{1.1.5} [CodeChicken Core] (minecraft.jar) 
	UCHIJAAAAA	CropLoadCoreASM{0.0.2} [CroploadCore ASM Core] (minecraft.jar) 
	UCHIJAAAAA	InputFix{1.7.10-v5} [InputFix] (minecraft.jar) 
	UCHIJAAAAA	NotEnoughItems{2.2.9-GTNH-pre} [NotEnoughItems] (NotEnoughItems-1.7.10-2.2.9-GTNH-pre.jar) 
	UCHIJAAAAA	OmniOcularCore{1.0} [Omni Ocular Core] (minecraft.jar) 
	UCHIJAAAAA	OpenComputers|Core{1.7.5.24-GTNH} [OpenComputers (Core)] (minecraft.jar) 
	UCHIJAAAAA	PlayerAPI{1.4} [Player API] (minecraft.jar) 
	UCHIJAAAAA	ThE-core{1.0.0.1} [Thaumic Energistics Core] (minecraft.jar) 
	UCHIJAAAAA	ThaumicTinkerer-preloader{0.1} [Thaumic Tinkerer Core] (minecraft.jar) 
	UCHIJAAAAA	WitchingGadgetsCore{1.2.18-GTNH} [Witching Gadgets Core] (minecraft.jar) 
	UCHIJAAAAA	OpenModsCore{0.10.6} [OpenModsCore] (minecraft.jar) 
	UCHIJAAAAA	<CoFH ASM>{000} [CoFH ASM] (minecraft.jar) 
	UCHIJAAAAA	GT++_Preloader{0.5-Beta} [GT++ Preloader] (minecraft.jar) 
	UCHIJAAAAA	NettyPatch_ASM{0.3.1} [NettyPatch_ASM] (minecraft.jar) 
	UCHIJAAAAA	WitcheryExtras_ASM{0.1-Beta} [WitcheryExtras_ASM] (minecraft.jar) 
	UCHIJAAAAA	BWCore{0.0.1} [BartWorks ASM Core] (minecraft.jar) 
	UCHIJAAAAA	FastCraft{1.25} [FastCraft] (fastcraft-1.25.jar) 
	UCHIJAAAAA	IC2{2.2.828-experimental} [IndustrialCraft 2] (industrialcraft-2-2.2.828a-experimental.jar) 
	UCHIJAAAAA	AdvancedSolarPanel{1.7.10-3.5.1} [Advanced Solar Panels] (AdvancedSolarPanel-1.7.10-3.5.1a.jar) 
	UCHIJAAAAA	adventurebackpack{1.0.4-GTNH} [Adventure Backpack] (adventurebackpack-1.7.10-1.0.4-GTNH.jar) 
	UCHIJAAAAA	appliedenergistics2{rv3-beta-80-GTNH-pre} [Applied Energistics 2] (appliedenergistics2-1.7.10-rv3-beta-80-GTNH-pre.jar) 
	UCHIJAAAAA	bdlib{1.9.6} [BD lib] (bdlib-1.7.10-1.9.6.jar) 
	UCHIJAAAAA	ae2stuff{0.5.1.15-GTNH} [AE2 Stuff] (ae2stuff-1.7.10-0.5.1.15-GTNH.jar) 
	UCHIJAAAAA	AFSU{1.2.6-GTNH} [AFSU Mod] (AFSU-1.7.10-1.2.6-GTNH.jar) 
	UCHIJAAAAA	YAMCore{0.5.82} [YAMCore] (YAMCore-1.7.10-0.5.82.jar) 
	UCHIJAAAAA	Baubles{1.0.1.14} [Baubles] (Baubles-1.7.10-1.0.1.14.jar) 
	UCHIJAAAAA	angermod{0.6.3} [AngerMod. Makes your Mobs angry!] (AngerMod-1.7.10-0.6.3.jar) 
	UCHIJAAAAA	AppleCore{3.1.9} [AppleCore] (AppleCore-1.7.10-3.1.9.jar) 
	UCHIJAAAAA	ArchitectureCraft{1.7.6} [ArchitectureCraft] (ArchitectureCraft-1.7.10-1.7.6.jar) 
	UCHIJAAAAA	Aroma1997CoreHelper{1.0.2.16} [Aroma1997Core|Helper] (Aroma1997Core-1.7.10-1.0.2.16.jar) 
	UCHIJAAAAA	AromaBackup{0.1.0.0} [AromaBackup] (AromaBackup-1.7.10-0.1.0.0.jar) 
	UCHIJAAAAA	AromaBackupRecovery{1.0} [AromaBackup Recovery] (AromaBackup-1.7.10-0.1.0.0.jar) 
	UCHIJAAAAA	CoFHCore{1.7.10R3.1.4} [CoFH Core] (CoFHCore-[1.7.10]3.1.4-329.jar) 
	UCHIJAAAAA	asielib{0.5.3} [AsieLib] (AsieLib-1.7.10-0.5.3.jar) 
	UCHIJAAAAA	Thaumcraft{4.2.3.5} [Thaumcraft] (Thaumcraft-1.7.10-4.2.3.5.jar) 
	UCHIJAAAAA	Waila{1.5.20} [Waila] (Waila-1.7.10-1.5.20.jar) 
	UCHIJAAAAA	Automagy{0.28.2} [Automagy] (Automagy-1.7.10-0.28.2.jar) 
	UCHIJAAAAA	AWWayofTime{1.3.8} [AlchemicalWizardry] (BloodMagic-1.7.10-1.3.8.jar) 
	UCHIJAAAAA	Botania{1.9.3-GTNH-pre} [Botania] (Botania-1.7.10-1.9.3-GTNH-pre.jar) 
	UCHIJAAAAA	Avaritia{1.25} [Avaritia] (Avaritia-1.7.10-1.25.jar) 
	UCHIJAAAAA	wanionlib{1.8.2} [WanionLib] (WanionLib-1.7.10-1.8.2.jar) 
	UCHIJAAAAA	avaritiaddons{1.5.3-GTNH} [Avaritiaddons] (Avaritiaddons-1.7.10-1.5.3-GTNH.jar) 
	UCHIJAAAAA	Backpack{2.2.5-GTNH} [Backpack Editted for ModdedNetwork] (backpack-1.7.10-2.2.5-GTNH.jar) 
	UCHIJAAAAA	Mantle{0.3.4} [Mantle] (Mantle-1.7.10-0.3.4.jar) 
	UCHIJAAAAA	battlegear2{1.7.10-1.1.1.8} [Mine & Blade Battlegear 2] (battlegear2-1.7.10-1.1.1.8.jar) 
	UCHIJAAAAA	ForgeMultipart{1.2.7} [Forge Multipart] (ForgeMultipart-1.7.10-1.2.7.jar) 
	UCHIJAAAAA	BuildCraft|Core{7.1.27} [BuildCraft] (buildcraft-1.7.10-7.1.27.jar) 
	UCHIJAAAAA	ExtraUtilities{1.2.12} [Extra Utilities] (extrautilities-1.2.13a.jar) 
	UCHIJAAAAA	TConstruct{1.7.10-1.9.0.14-GTNH} [Tinkers' Construct] (TConstruct-1.7.10-1.9.0.14-GTNH.jar) 
	UCHIJAAAAA	Natura{2.5.0} [Natura] (Natura-1.7.10-2.5.0.jar) 
	UCHIJAAAAA	BiomesOPlenty{2.1.3-GTNH} [Biomes O' Plenty] (BiomesOPlenty-1.7.10-2.1.3-GTNH.jar) 
	UCHIJAAAAA	HardcoreEnderExpansion{1.9.2-GTNH} [Hardcore Ender Expansion] (HardcoreEnderExpansion-1.7.10-1.9.2-GTNH.jar) 
	UCHIJAAAAA	Forestry{4.4.6} [Forestry] (Forestry-1.7.10-4.4.6.jar) 
	UCHIJAAAAA	BinnieCore{2.0.34} [Binnie Core] (binnie-mods-1.7.10-2.0.34.jar) 
	UCHIJAAAAA	ExtraTrees{2.0.34} [Extra Trees] (binnie-mods-1.7.10-2.0.34.jar) 
	UCHIJAAAAA	BuildCraft|Energy{7.1.27} [BC Energy] (buildcraft-1.7.10-7.1.27.jar) 
	UCHIJAAAAA	GalacticraftCore{3.0.40-GTNH} [Galacticraft Core] (Galacticraft-1.7.10-3.0.40-GTNH.jar) 
	UCHIJAAAAA	BuildCraft|Transport{7.1.27} [BC Transport] (buildcraft-1.7.10-7.1.27.jar) 
	UCHIJAAAAA	BuildCraft|Factory{7.1.27} [BC Factory] (buildcraft-1.7.10-7.1.27.jar) 
	UCHIJAAAAA	BuildCraft|Builders{7.1.27} [BC Builders] (buildcraft-1.7.10-7.1.27.jar) 
	UCHIJAAAAA	BuildCraft|Silicon{7.1.27} [BC Silicon] (buildcraft-1.7.10-7.1.27.jar) 
	UCHIJAAAAA	GalacticraftMars{3.0.40-GTNH} [Galacticraft Planets] (Galacticraft-1.7.10-3.0.40-GTNH.jar) 
	UCHIJAAAAA	Railcraft{9.13.7-pre.dirty} [Railcraft] (Railcraft-1.7.10-9.13.7-pre.dirty.jar) 
	UCHIJAAAAA	TwilightForest{2.3.8.14} [The Twilight Forest] (TwilightForest-1.7.10-2.3.8.14.jar) 
	UCHIJAAAAA	chisel{2.10.9-GTNH} [Chisel] (chisel-1.7.10-2.10.9-GTNH.jar) 
	UCHIJAAAAA	endercore{0.2.6} [EnderCore] (endercore-1.7.10-0.2.6.jar) 
	UCHIJAAAAA	EnderIO{2.3.1.31} [Ender IO] (EnderIO-1.7.10-2.3.1.31.jar) 
	UCHIJAAAAA	supersolarpanel{1.7.10-1.1.1-GT-NH-Mod} [Super Solar Panel] (SSP-1.1.2-GT-NH-Mod.jar) 
	UCHIJAAAAA	dreamcraft{1.9.22-pre} [GT: New Horizons] (GTNewHorizonsCoreMod-1.7.10-1.9.22-pre.jar) 
	UCHIJAAAAA	harvestcraft{1.0.12-GTNH} [Pam's HarvestCraft] (Pam's_Harvestcraft-1.7.10-1.0.12-GTNH.jar) 
	UCHIJAAAAA	structurelib{1.0.16} [StructureLib] (structurelib-1.7.10-1.0.16.jar) 
	UCHIJAAAAA	Translocator{1.1.2.19} [Translocator] (Translocator-1.7.10-1.1.2.19.jar) 
	UCHIJAAAA	gregtech{MC1710} [GregTech] (gregtech-1.7.10-5.09.40.40.-pre.jar) 
	UCHIJAAAAA	DummyCore{1.13} [DummyCore] (DummyCore1.13.jar) 
	UCHIJAAAAA	thaumicbases{1.4.29} [Thaumic Bases] (Thaumic-Based-1.7.10-1.4.29.jar) 
	UCHIJAAAAA	witchery{0.24.1} [Witchery] (witchery-1.7.10-0.24.1.jar) 
	UCHIJAAAAA	Ztones{1.7.10} [Ztones] (Ztones-1.7.10-2.2.2.jar) 
	UCHIJAAAAA	croploadcore{0.1.10} [CropLoadCore] (CropLoadCore-1.7.10-0.1.10.jar) 
	UCHIJAAAAA	berriespp{1.3.5.9} [Crops++] (CropsPP-1.7.10-1.3.5.9.jar) 
	UCHIJAAAAA	EnderStorage{1.4.11} [EnderStorage] (EnderStorage-1.7.10-1.4.11.jar) 
	UCHIJAAAAA	MrTJPCoreMod{1.1.0.33} [MrTJPCore] (MrTJPCore-1.1.0.33-universal.jar) 
	UCHIJAAAAA	ProjRed|Core{4.7.5} [ProjectRed Core] (ProjRed-1.7.10-4.7.5.jar) 
	UCHIJAAAAA	ProjRed|Transmission{4.7.5} [ProjectRed Transmission] (ProjRed-1.7.10-4.7.5.jar) 
	UCHIJAAAAA	OpenComputers{1.7.5.24-GTNH} [OpenComputers] (OpenComputers-1.7.10-1.7.5.24-GTNH.jar) 
	UCHIJAAAAA	tectech{5.0.6} [TecTech - Tec Technology!] (TecTech-1.7.10-5.0.6.jar) 
	UCHIJAAAAA	bartworks{0.5.40-pre} [BartWorks] (bartworks-1.7.10-0.5.40-pre.jar) 
	UCHIJAAAAA	ThaumicTinkerer{2.6.4} [Thaumic Tinkerer] (ThaumicTinkerer-1.7.10-2.6.4.jar) 
	UCHIJAAAAA	ForbiddenMagic{0.6.2-GTNH} [Forbidden Magic] (Forbidden Magic-1.7.10-0.6.2-GTNH.jar) 
	UCHIJAAAAA	ExtraBees{2.0.34} [Extra Bees] (binnie-mods-1.7.10-2.0.34.jar) 
	UCHIJAAAAA	MagicBees{2.5.8-GTNH} [Magic Bees] (magicbees-1.7.10-2.5.8-GTNH.jar) 
	UCHIJAAAAA	EMT{1.2.8.7} [Electro-Magic Tools] (EMT-1.7.10-1.2.8.7.jar) 
	UCHIJAAAAA	bartworkscrossmodtgregworkscontainer{0.5.40-pre} [BartWorks Mod Additions - TGregworks Container] (bartworks-1.7.10-0.5.40-pre.jar) 
	UCHIJAAAAA	GoodGenerator{0.4.1} [Good Generator] (GoodGenerator-1.7.10-0.4.1.jar) 
	UCHIJAAAAA	gtnhlanth{0.8.6} [GTNH: Lanthanides] (gtnhlanth-1.7.10-0.8.6.jar) 
	UCHIJAAAAA	IC2NuclearControl{2.4.8} [Nuclear Control 2] (IC2NuclearControl-1.7.10-2.4.8.jar) 
	UCHIJAAAAA	OpenMods{0.10.6} [OpenMods] (OpenModsLibs-1.7.10-0.10.6.jar) 
	UCHIJAAAAA	OpenBlocks{1.6.8-GTNH} [OpenBlocks] (OpenBlocks-1.7.10-1.6.8-GTNH.jar) 
	UCHIJAAAAA	StevesCarts{2.0.1} [Steve's Carts 2] (StevesCarts-1.7.10-2.0.1.jar) 
	UCHIJAAAAA	TGregworks{GTNH-1.0.22} [Tinkers' Gregworks] (TGregworks-1.7.10-GTNH-1.0.22.jar) 
	UCHIJAAAAA	miscutils{1.7.30-pre} [GT++] (GT-PlusPlus-1.7.10-1.7.30-pre.jar) 
	UCHIJAAAAA	bartworkscrossmod{0.5.40-pre} [BartWorks Mod Additions] (bartworks-1.7.10-0.5.40-pre.jar) 
	UCHIJAAAAA	beebetteratbees{0.2} [BeeBetterAtBees] (BeeBetterAtBees-0.3.jar) 
	UCHIJAAAAA	BetterAchievements{0.1.0} [Better Achievements] (BetterAchievements-1.7.10-0.1.0.jar) 
	UCHIJAAAAA	betterbuilderswands{1.7.10-0.9.1-GTNH} [BetterBuildersWands] (BetterBuildersWands-1.7.10-0.9.1-GTNH.jar) 
	UCHIJAAAAA	betterloadingscreen{1.3.32-GTNH} [Better Loading Screen GTNH] (betterloadingscreen-1.7.10-1.3.32-GTNH.jar) 
	UCHIJAAAAA	forgelin{1.9.2-GTNH-1.7.10-Edition} [GTNH's Forgelin 1.7.10] (Forgelin-1.9.2-GTNH-1.7.10-Edition.jar) 
	UCHIJAAAAA	betterp2p{1.0.6} [BetterP2P] (betterp2p-1.7.10-1.0.6.jar) 
	UCHIJAAAAA	betterquesting{3.0.355-GTNH} [BetterQuesting] (BetterQuesting-1.7.10-3.0.355-GTNH.jar) 
	UCHIJAAAAA	BiblioCraft{1.11.7} [BiblioCraft] (BiblioCraft[v1.11.7][MC1.7.10].jar) 
	UCHIJAAAAA	BiblioWoodsBoP{1.9} [BiblioWoods Biomes O'Plenty Edition] (BiblioWoods[BiomesOPlenty][v1.9].jar) 
	UCHIJAAAAA	BiblioWoodsForestry{1.7} [BiblioWoods Forestry Edition] (BiblioWoods[Forestry][v1.7].jar) 
	UCHIJAAAAA	BiblioWoodsNatura{1.5} [BiblioWoods Natura Edition] (BiblioWoods[Natura][v1.5].jar) 
	UCHIJAAAAA	Botany{2.0.34} [Botany] (binnie-mods-1.7.10-2.0.34.jar) 
	UCHIJAAAAA	Genetics{2.0.34} [Genetics] (binnie-mods-1.7.10-2.0.34.jar) 
	UCHIJAAAAA	blocklimiter{0.55} [BlockLimiter. Restrict your Blocks] (BlockLimiter-1.7.10-0.55.jar) 
	UCHIJAAAAA	BloodArsenal{1.7.10-1.2.5} [Blood Arsenal] (BloodArsenal-1.7.10-1.2.5.jar) 
	UCHIJAAAAA	botanichorizons{1.0.5-GTNH} [botanichorizons] (BotanicHorizons-1.7.10-1.0.5-GTNH.jar) 
	UCHIJAAAAA	BrandonsCore{1.0.0.12} [Brandon's Core] (BrandonsCore-1.0.0.12.jar) 
	UCHIJAAAAA	spongemixins{1.5.0} [SpongeMixins Loader] (SpongeMixins-1.5.0.jar) 
	UCHIJAAAAA	bugtorch{1.1.2-GTNH} [Bug Torch] (BugTorch-1.1.2-GTNH.jar) 
	UCHIJAAAAA	BuildCraft|Robotics{7.1.27} [BC Robotics] (buildcraft-1.7.10-7.1.27.jar) 
	UCHIJAAAAA	BuildCraft|Compat{7.1.11} [BuildCraft Compat] (buildcraft-compat-1.7.10-7.1.11.jar) 
	UCHIJAAAAA	OilTweak{1.0.3} [BuildCraft Oil Tweak] (BuildCraftOilTweak-1.7.10-1.0.3.jar) 
	UCHIJAAAAA	CarpentersBlocks{3.3.8.2} [Carpenter's Blocks] (Carpenter's Blocks v3.3.8.2 - MC 1.7.10.jar) 
	UCHIJAAAAA	catwalks{2.0.4} [Catwalks Mod] (catwalks-1.7.10-2.1.3-GTNH.jar) 
	UCHIJAAAAA	cb4bq{1} [Command Blocks for Better Questing] (CB4BQ-3.jar) 
	UCHIJAAAAA	chiseltones{@VERSION@} [Chisel Tones] (ChiselTones-1.7.10-1.0-3.jar) 
	UCHIJAAAAA	compactkineticgenerators{1.7.10-1.0} [Compact Kinetic Wind and Water Generators] (CompactKineticGenerators-1.7.10-1.0.jar) 
	UCHIJAAAAA	computronics{1.6.11-GTNH} [Computronics] (Computronics-1.7.10-1.6.11-GTNH.jar) 
	UCHIJAAAAA	controlling{1.0.0} [Controlling] (Controlling-1.7.10-1.0.0.jar) 
	UCHIJAAAAA	cookingforblockheads{1.2.8-GTNH} [Cooking For Blockheads] (CookingForBlockheads-1.7.10-1.2.8-GTNH.jar) 
	UCHIJAAAAA	craftpresence{1.8.2} [CraftPresence] (CraftPresence-Forge-1.7.10-Release-1.8.2.jar) 
	UCHIJAAAAA	MineTweaker3{3.1.0} [MineTweaker 3] (CraftTweaker-1.7.10-3.2.3-GTNH.21-legacy.jar) 
	UCHIJAAAAA	creativecore{1.3.25-GTNH} [CreativeCore] (creativecore-1.7.10-1.3.25-GTNH.jar) 
	UCHIJAAAAA	CustomMainMenu{1.9.2} [Custom Main Menu] (CustomMainMenu-MC1.7.10-1.9.2.jar) 
	UCHIJAAAAA	defaultserverlist{1.0} [DefaultServerList] (defaultserverlist-1.7.10-1.0.jar) 
	UCHIJAAAAA	defaultworldgenerator{0.1-b13} [Default World Generator] (DefaultWorldGenerator-1.7.10-0.1-b13-universal.jar) 
	UCHIJAAAAA	DraconicEvolution{1.1.1} [Draconic Evolution] (Draconic-Evolution-1.7.10-1.1.1.jar) 
	UCHIJAAAAA	EnderZoo{1.0.23} [Ender Zoo] (EnderZoo-1.7.10-1.0.23.jar) 
	UCHIJAAAAA	enhancedlootbags{1.0.5} [Enhanced LootBags] (EnhancedLootBags-1.7.10-1.0.5.jar) 
	UCHIJAAAAA	enhancedportals{3.0.12} [EnhancedPortals] (EnhancedPortals_1.7.10-universal-3.0.12.jar) 
	UCHIJAAAAA	universalsingularities{8.6.5} [UniversalSingularities] (Universal-Singularities-1.7.10-8.6.5.jar) 
	UCHIJAAAAA	eternalsingularity{1.7.10-.1.0.4b} [Eternal Singularity] (EternalSingularity-1.7.10-1.0.4b.jar) 
	UCHIJAAAAA	extracells{2.5.10} [Extra Cells] (ExtraCells-1.7.10-2.5.10.jar) 
	UCHIJAAAAA	findit{1.0.5} [FindIt] (findit-1.7.10-1.0.5.jar) 
	UCHIJAAAAA	FloodLights{1.2.8-137} [Flood Lights] (FloodLights-1.7.10-1.2.8-137.jar) 
	UCHIJAAAAA	FpsReducer{1.7.10-1.7} [FPS Reducer] (FpsReducer-1.7.10-1.7.jar) 
	UCHIJAAAAA	fw{1.3.0} [Fullscreen Windowed] (FullscreenWindowed-1.7.10-1.3.0b.jar) 
	UCHIJAAAAA	gadomancy{1.0.8.4} [Gadomancy] (gadomancy-1.7.10-1.0.8.4.jar) 
	UCHIJAAAAA	galacticgreg{1.0.7} [Galactic Greg] (galacticgreg-1.7.10-1.0.7.jar) 
	UCHIJAAAAA	IronChest{6.0.70} [Iron Chests] (IronChest-1.7.10-6.0.70.jar) 
	UCHIJAAAAA	openmodularturrets{2.2.11-247} [Open Modular Turrets] (OpenModularTurrets-1.7.10-2.2.11-247.jar) 
	UCHIJAAAAA	GalaxySpace{1.1.16-GTNH} [GalaxySpace] (GalaxySpace-1.7.10-1.1.16-GTNH.jar) 
	UCHIJAAAAA	gendustry{1.6.5.3-GTNH} [Gendustry] (gendustry-1.7.10-1.6.5.3-GTNH.jar) 
	UCHIJAAAAA	GraviSuite{2.0.68u} [Graviation Suite] (GraviSuite-1.7.10-2.0.68u.jar) 
	UCHIJAAAAA	detravscannermod{1.6.6} [GT Scanner Mod] (GT Scanner Mod-1.7.10-1.6.6.jar) 
	UCHIJAAAAA	Australia{1.7.30-pre} [GT++ Australia] (GT-PlusPlus-1.7.10-1.7.30-pre.jar) 
	UCHIJAAAAA	ToxicEverglades{1.7.30-pre} [GT++ ToxicEverglades] (GT-PlusPlus-1.7.10-1.7.30-pre.jar) 
	UCHIJAAAAA	gtneioreplugin{1.0.10} [GT NEI Ore Plugin GT:NH Mod] (gtneioreplugin-1.7.10-1.0.10.jar) 
	UCHIJAAAAA	TaintedMagic{r7.6} [Tainted Magic] (Tainted-Magic-r7.6.jar) 
	UCHIJAAAAA	ThaumicExploration{GRADLETOKEN_VERSION} [Thaumic Exploration] (Thaumic-Exploration-1.7.10-1.1.84-GTNH.jar) 
	UCHIJAAAAA	gtnhtcwands{1.2.6} [GTNH-TC-Wands] (GTNH-TC-Wands-1.7.10-1.2.6.jar) 
	UCHIJAAAAA	GTTweaker{1.0} [GTTweaker] (GTTweaker-1.7.10-1.7.5.jar) 
	UCHIJAAAAA	HardcoreDarkness{1.7} [Hardcore Darkness] (HardcoreDarkness-MC1.7.10-1.7.jar) 
	UCHIJAAAAA	HelpFixer{1.0.7} [HelpFixer] (HelpFixer-1.0.7.jar) 
	UCHIJAAAAA	hodgepodge{1.7.1} [Hodgepodge] (hodgepodge-1.7.10-1.7.1.jar) 
	UCHIJAAAAA	holoinventory{1.7.10-2.1.7-GTNH} [Holo Inventory] (holoinventory-1.7.10-2.1.7-GTNH.jar) 
	UCHIJAAAAA	hydroenergy{1.0.10} [HydroEnergy] (hydroenergy-1.7.10-1.0.10.jar) 
	UCHIJAAAAA	Ic2Nei{1.2.1} [IC2 Crop Plugin] (IC2+Crop+Plugin+Version+1.7.10-1.3.1.jar) 
	UCHIJAAAAA	ifu{1.9.2} [I Will Find You] (ifu-1.7.10-1.9.2.jar) 
	UCHIJAAAAA	InfernalMobs{1.7.5-GTNH} [Infernal Mobs] (InfernalMobs-1.7.10-1.7.5-GTNH.jar) 
	UCHIJAAAAA	LunatriusCore{1.1.6-GTNH} [LunatriusCore] (LunatriusCore-1.7.10-1.1.6-GTNH.jar) 
	UCHIJAAAAA	InGameInfoXML{2.8.3.91} [InGame Info XML] (InGameInfoXML-1.7.10-2.8.3.91.jar) 
	UCHIJAAAAA	inpure|core{1.7.10R1.0.0B9} [INpureCore] (INpureCore-1.7.10-1.1.1-GTNH.jar) 
	UCHIJAAAAA	inventorytweaks{1.7.10} [Inventory Tweaks] (inventorytweaks-1.7.10-1.5.13.jar) 
	UCHIJAAAAA	ironchestminecarts{1.0.8} [Iron Chest Minecarts] (IronChestMinecarts-1.7.10-1.0.8.jar) 
	UCHIJAAAAA	irontank{1.2.6} [Iron Tanks] (irontanks-1.7.10-1.2.6.jar) 
	UCHIJAAAAA	itlt{1.0.3} [It's the little things] (itlt-1.7.x-1.0.3.jar) 
	UCHIJAAAAA	JABBA{1.2.14} [JABBA] (JABBA-1.7.10-1.2.14.jar) 
	UCHIJAAAAA	journeymap{5.1.4p2} [JourneyMap] (journeymap-1.7.10-5.1.4p2-fairplay.jar) 
	UCHIJAAAAA	kekztech{0.6.3} [KekzTech] (kekztech-1.7.10-0.6.3.jar) 
	UCHIJAAAAA	littletiles{1.2.1-GTNH} [LittleTiles] (littletiles-1.7.10-1.2.1-GTNH.jar) 
	UCHIJAAAAA	LogisticsPipes{0.9.4.5.4} [Logistics Pipes] (logisticspipes-0.9.4.5.4.jar) 
	UCHIJAAAAA	lootgames{2.0.5} [LootGames] (lootgames-1.7.10-2.0.5.jar) 
	UCHIJAAAAA	malisiscore{1.7.10-0.14.3} [MalisisCore] (malisiscore-1.7.10-0.14.3.jar) 
	UCHIJAAAAA	malisisdoors{1.7.10-1.13.2} [Malisis' Doors] (malisisdoors-1.7.10-1.13.2.jar) 
	UCHIJAAAAA	ModMixins{0.0.1} [ModMixins] (modmixins-1.7.10-0.0.5.jar) 
	UCHIJAAAAA	modtweaker2{0.9.8} [Mod Tweaker 2] (ModTweaker2-1.7.10-0.9.8.jar) 
	UCHIJAAAAA	MouseTweaks{2.4.4} [Mouse Tweaks] (MouseTweaks-2.4.4-mc1.7.10.jar) 
	UCHIJAAAAA	naturescompass{1.3.1} [Nature's Compass] (NaturesCompass-1.7.10-1.3.1.jar) 
	UCHIJAAAAA	NEIAddons{1.12.19} [NEI Addons] (NEIAddons-1.7.10-1.12.19.jar) 
	UCHIJAAAAA	NEIAddons|CraftingTables{1.12.19} [NEI Addons: Crafting Tables] (NEIAddons-1.7.10-1.12.19.jar) 
	UCHIJAAAAA	NEIAddons|AppEng{1.12.19} [NEI Addons: Applied Energistics 2] (NEIAddons-1.7.10-1.12.19.jar) 
	UCHIJAAAAA	NEIAddons|Developer{1.12.19} [NEI Addons: Developer Tools] (NEIAddons-1.7.10-1.12.19.jar) 
	UCHIJAAAAA	NEIAddons|ExNihilo{1.12.19} [NEI Addons: Ex Nihilo] (NEIAddons-1.7.10-1.12.19.jar) 
	UCHIJAAAAA	NEIAddons|Botany{1.12.19} [NEI Addons: Botany] (NEIAddons-1.7.10-1.12.19.jar) 
	UCHIJAAAAA	NEIAddons|Forestry{1.12.19} [NEI Addons: Forestry] (NEIAddons-1.7.10-1.12.19.jar) 
	UCHIJAAAAA	neicustomdiagram{1.4.4.4} [NEI Custom Diagram] (NEICustomDiagram-1.7.10-1.4.4.4.jar) 
	UCHIJAAAAA	neieasysearch{0.8.11} [NEI Easy Search] (neieasysearch-E-1.7.10-0.8.11.jar) 
	UCHIJAAAAA	neiintegration{1.1.3} [NEIIntegration] (NEIIntegration-1.7.10-1.1.3.jar) 
	UCHIJAAAAA	netherportalfix{1.0} [Nether Portal Fix] (netherportalfix-mc1.7.10-1.1.1.jar) 
	UCHIJAAAAA	NettyPatch{0.3.1} [NettyPatch] (NettyPatch-1.7.10-0.3.1.jar) 
	UCHIJAAAAA	NodalMechanics{1.1.-6-GTNH} [NodalMechanics] (NodalMechanics-1.7.10-1.1.-6-GTNH.jar) 
	UCHIJAAAAA	nechar{1.3.1} [Not Enough Characters] (NotEnoughCharacters-1.7.10-1.3.1.jar) 
	UCHIJAAAAA	ae2wct{1.8.8.4-pre} [AE2 Wireless Crafting Terminal] (WirelessCraftingTerminal-1.7.10-1.8.8.4-pre.jar) 
	UCHIJAAAAA	neenergistics{1.3.11} [NotEnoughEnergistics] (NotEnoughEnergistics-1.7.10-1.3.11.jar) 
	UCHIJAAAAA	oauth{1.06.1-GTNH} [OAuth] (oauth-1.7.10-1.06.1-GTNH.jar) 
	UCHIJAAAAA	OmniOcular{1.7.10-1.0build103} [Omni Ocular] (OmniOcular-OO-1.7.10-1.0build103.jar) 
	UCHIJAAAAA	openglasses{1.2.3-GTNH} [OC Glasses] (OpenGlasses-1.7.10-1.2.3-GTNH.jar) 
	UCHIJAAAAA	openprinter{0.1.0.132} [OpenPrinter] (OpenPrinter-MC1.7.10-0.1.0.132.jar) 
	UCHIJAAAAA	opensecurity{1.0.117} [OpenSecurity] (OpenSecurity-1.7.10-1.0-117.jar) 
	UCHIJAAAAA	oreexcavation{1.1.134} [OreExcavation] (OreExcavation-连锁-1.1.134.jar) 
	UCHIJAAAAA	overloadedarmorbar{1.0.1} [Overloaded Armor Bar] (overloadedarmorbar-1.7.10-1.0.1.jar) 
	UCHIJAAAAA	p455w0rdslib{1.0.4} [p455w0rd's Library] (p455w0rdslib-1.7.10-1.0.4.jar) 
	UCHIJAAAAA	harvestthenether{1.7.10} [Pam's Harvest the Nether] (Pam's Harvest the Nether 1.7.10a.jar) 
	UCHIJAAAAA	ProjectBlue{1.1.7-GTNH} [Project Blue] (ProjectBlue-1.7.10-1.1.7-GTNH.jar) 
	UCHIJAAAAA	ProjRed|Exploration{4.7.5} [ProjectRed Exploration] (ProjRed-1.7.10-4.7.5.jar) 
	UCHIJAAAAA	ProjRed|Expansion{4.7.5} [ProjectRed Expansion] (ProjRed-1.7.10-4.7.5.jar) 
	UCHIJAAAAA	ProjRed|Illumination{4.7.5} [ProjectRed Illumination] (ProjRed-1.7.10-4.7.5.jar) 
	UCHIJAAAAA	ProjRed|Transportation{4.7.5} [ProjectRed Transportation] (ProjRed-1.7.10-4.7.5.jar) 
	UCHIJAAAAA	ProjRed|Compatibility{4.7.5} [ProjectRed Compatibility] (ProjRed-1.7.10-4.7.5.jar) 
	UCHIJAAAAA	ProjRed|Integration{4.7.5} [ProjectRed Integration] (ProjRed-1.7.10-4.7.5.jar) 
	UCHIJAAAAA	ProjRed|Fabrication{4.7.5} [ProjectRed Fabrication] (ProjRed-1.7.10-4.7.5.jar) 
	UCHIJAAAAA	questbook{2.1.3-GTNH} [Better Questing Quest Book] (questbook-1.7.10-2.1.3-GTNH.jar) 
	UCHIJAAAAA	RandomThings{2.2.4} [Random Things] (RandomThings-2.2.4.jar) 
	UCHIJAAAAA	RIO{2.4.5} [RemoteIO] (RemoteIO-1.7.10-2.4.5.jar) 
	UCHIJAAAAA	ResourceLoader{1.3} [Resource Loader] (ResourceLoader-MC1.7.10-1.3.jar) 
	UCHIJAAAAA	Roguelike{1.5.2-GTNH} [Roguelike Dungeons] (roguelike-1.7.10-1.5.2-GTNH.jar) 
	UCHIJAAAAA	RWG{Alpha 1.3.2} [Realistic World Gen Alpha] (RWG-alpha-1.3.2.jar) 
	UCHIJAAAAA	Schematica{1.8.5-GTNH} [Schematica] (Schematica-1.7.10-1.8.5-GTNH.jar) 
	UCHIJAAAAA	SGCraft{1.3.12-GTNH} [SG Craft] (SGCraft-1.7.10-1.3.12-GTNH.jar) 
	UCHIJAAAAA	sleepingbag{1.7.10-0.1.2} [Sleeping Bag] (sleepingbag-1.7.10-0.1.2.jar) 
	UCHIJAAAAA	SpecialMobs{3.3.9} [Special Mobs] (SpecialMobs-1.7.10-3.3.9.jar) 
	UCHIJAAAAA	SpiceOfLife{v.2.0.0-carrot-beta10} [The Spice of Life - Carrot Edition] (SpiceOfLife-1.7.10-v.2.0.0-carrot-beta10.jar) 
	UCHIJAAAAA	bq_standard{3.0.190-GTNH} [Standard Expansion] (StandardExpansion-1.7.10-3.0.190-GTNH.jar) 
	UCHIJAAAAA	StevesFactoryManager{1.1.0-GTNH} [Steve's Factory Manager] (StevesFactoryManager-1.7.10-1.1.0-GTNH.jar) 
	UCHIJAAAAA	StevesAddons{0.10.23} [Steve's Addons] (StevesAddons-1.7.10-0.10.23.jar) 
	UCHIJAAAAA	StorageDrawers{1.11.13-GTNH} [Storage Drawers] (StorageDrawers-1.7.10-1.11.13-GTNH.jar) 
	UCHIJAAAAA	StorageDrawersBop{1.11.11-GTNH} [Storage Drawers: Biomes O' Plenty Pack] (StorageDrawersBop-1.7.10-1.11.11-GTNH.jar) 
	UCHIJAAAAA	StorageDrawersForestry{1.11.11-GTNH} [Storage Drawers: Forestry Pack] (StorageDrawersForestry-1.7.10-1.11.11-GTNH.jar) 
	UCHIJAAAAA	StorageDrawersMisc{1.11.11-GTNH} [Storage Drawers: Misc Pack] (StorageDrawersMisc-1.7.10-1.11.11-GTNH.jar) 
	UCHIJAAAAA	StorageDrawersNatura{1.11.11-GTNH} [Storage Drawers: Natura Pack] (StorageDrawersNatura-1.7.10-1.11.11-GTNH.jar) 
	UCHIJAAAAA	SuperTic{1.2.2} [SuperTic] (SuperTic-1.7.10-1.2.2.jar) 
	UCHIJAAAAA	tcinventoryscan{1.0.11} [TC Inventory Scanning] (tcinventoryscan-mc1.7.10-1.0.11.jar) 
	UCHIJAAAAA	thaumcraftneiplugin{@VERSION@} [Thaumcraft NEI Plugin] (thaumcraftneiplugin-1.7.10-1.7a.jar) 
	UCHIJAAAAA	tcneiadditions{1.1.0.6} [Thaumcraft NEI Additions] (tcneiadditions-1.7.10-1.1.0.6.jar) 
	UCHIJAAAAA	tcnodetracker{1.1.5} [TC Node Tracker] (tcnodetracker-1.7.10-1.1.5.jar) 
	UCHIJAAAA	tc4tweak{1.4.16} [TC4 Tweak] (Thaumcraft4Tweaks-1.7.10-1.4.16.jar) 
	UCHIJAAAA	ThaumcraftMobAspects{1.0.0-GTNH} [Thaumcraft Mob Aspects] (ThaumcraftMobAspects-1.7.10-1.0.0-GTNH.jar) 
	UCHIJAAAA	ThaumcraftResearchTweaks{1.0.3} [Thaumcraft Research Tweaks] (ThaumcraftResearchTweaks-1.7.10-1.0.3.jar) 
	UCHIJAAAA	ThaumicMachina{0.2.1} [Thaumic Machina] (Thaumic Machina-1.7.10-0.2.1.jar) 
	UCHIJAAAA	thaumicenergistics{1.3.16-GTNH} [Thaumic Energistics] (thaumicenergistics-1.7.10-1.3.16-GTNH.jar) 
	UCHIJAAAA	ThaumicHorizons{1.2.1.2} [ThaumicHorizons] (ThaumicHorizons-1.7.10-1.2.1.2.jar) 
	UCHIJAAAA	TiCTooltips{1.2.9} [TiC Tooltips] (TiCTooltips-1.7.10-1.2.9.jar) 
	UCHIJAAAA	tinkersdefense{1.2} [Tinkers' Defense] (Tinkers-Defense-1.2.1d.jar) 
	UCHIJAAAA	TMechworks{0.2.16.3} [Tinkers Mechworks] (TMechworks-1.7.10-0.2.16.3.jar) 
	UCHIJAAAA	TML{4.1.0-GTNH} [TooMuchLoot] (TooMuchLoot-1.7.10-4.1.0-GTNH.jar) 
	UCHIJAAAA	torohealthmod{1.0.1} [ToroHealth Damage Indicators] (torohealth-1.7.10-1.0.1.jar) 
	UCHIJAAAA	TravellersGear{1.16.8-GTNH} [Traveller's Gear] (TravellersGear-1.7.10-1.16.8-GTNH.jar) 
	UCHIJAAAA	utilityworlds{1.0.9d} [Utility Worlds] (utilityworlds-1.0.9e.jar) 
	UCHIJAAAA	visualprospecting{1.0.28} [VisualProspecting] (visualprospecting-1.7.10-1.0.28.jar) 
	UCHIJAAAA	WailaHarvestability{1.1.10-GTNH} [Waila Harvestability] (WailaHarvestability-1.7.10-1.1.10-GTNH.jar) 
	UCHIJAAAA	wailaplugins{0.2.5} [WAILA Plugins] (WAILAPlugins-1.7.10-0.2.5.jar) 
	UCHIJAAAA	WarpTheory{1.2.6-GTNH} [WarpTheory] (WarpTheory-1.7.10-1.2.6-GTNH.jar) 
	UCHIJAAAA	wawla{1.1.3-GTNH} [What Are We Looking At] (Wawla-1.7.10-1.1.3-GTNH.jar) 
	UCHIJAAAA	WitcheryExtras{1.1.5} [Witchery++] (WitcheryExtras-1.7.10-1.1.5.jar) 
	UCHIJAAAA	WitchingGadgets{1.2.18-GTNH} [Witching Gadgets] (WitchingGadgets-1.7.10-1.2.18-GTNH.jar) 
	UCHIJAAAA	worldedit{6.0-beta-01} [WorldEdit] (worldedit-forge-mc1.7.10-6.0-beta-01.jar) 
	UCHIJAAAA	WR-CBE|Core{1.4.5} [WR-CBE Core] (WR-CBE-1.7.10-1.4.5.jar) 
	UCHIJAAAA	WR-CBE|Logic{1.4.5} [WR-CBE Logic] (WR-CBE-1.7.10-1.4.5.jar) 
	UCHIJAAAA	WR-CBE|Addons{1.4.5} [WR-CBE Addons] (WR-CBE-1.7.10-1.4.5.jar) 
	UCHIJAAAA	McMultipart{1.2.7} [Minecraft Multipart Plugin] (ForgeMultipart-1.7.10-1.2.7.jar) 
	UCHIJAAAA	ForgeMicroblock{1.2.7} [Forge Microblocks] (ForgeMultipart-1.7.10-1.2.7.jar) 
	UCHIJAAAA	ForgeRelocation{0.0.1.4} [ForgeRelocation] (ForgeRelocation-0.0.1.4-universal.jar) 
	UCHIJAAAA	MCFrames{1.0} [MCFrames] (ForgeRelocation-0.0.1.4-universal.jar) 
	UCHIJAAAA	RelocationFMP{0.0.1.2} [RelocationFMP] (ForgeRelocationFMP-0.0.1.2-universal.jar) 
	UCHIJAAAA	HungerOverhaul{1.7.10-1.0.2.DEV.80bb6db} [Hunger Overhaul] (HungerOverhaul-1.7.10-1.0.2.jar) 
	UCHIJAAAA	IguanaTweaksTConstruct{1.7.10-2.2.2} [Iguana Tinker Tweaks] (IguanaTweaksTConstruct-1.7.10-2.2.2.jar) 
	OpenModsLib class transformers: [stencil_patches:FINISHED],[movement_callback:ACTIVATED],[player_damage_hook:FINISHED],[map_gen_fix:FINISHED],[gl_capabilities_hook:FINISHED],[player_render_hook:FINISHED]
	Class transformer null safety: all safe
	AE2 Version: rv3-beta-80-GTNH-pre for Forge 10.13.4.1614
	CoFHCore: -[1.7.10]3.1.4-329
	Mantle Environment: Environment healthy.
	TConstruct Environment: Environment healthy.
	TC4Tweak signing signature: None. Do not bother glease for this crash!
	List of loaded APIs: 
		* ae2wct|API (1.7.10-rv3-1.8.6b) from WirelessCraftingTerminal-1.7.10-1.8.8.4-pre.jar
		* AppleCoreAPI (${apiversion}) from AppleCore-1.7.10-3.1.9.jar
		* appliedenergistics2|API (rv3) from appliedenergistics2-1.7.10-rv3-beta-80-GTNH-pre.jar
		* AromaBackupAPI (1.0) from AromaBackup-1.7.10-0.1.0.0.jar
		* asielibAPI (1.1) from AsieLib-1.7.10-0.5.3.jar
		* asielibAPI|chat (1.0) from AsieLib-1.7.10-0.5.3.jar
		* asielibAPI|tile (1.0) from AsieLib-1.7.10-0.5.3.jar
		* asielibAPI|tool (1.1) from AsieLib-1.7.10-0.5.3.jar
		* bartworks API (@apiversion@) from bartworks-1.7.10-0.5.40-pre.jar
		* bartworks util (@apiversion@) from bartworks-1.7.10-0.5.40-pre.jar
		* BattlePlayer (0.1) from battlegear2-1.7.10-1.1.1.8.jar
		* Baubles|API (1.0.1.10) from Baubles-1.7.10-1.0.1.14.jar
		* BetterAchievements|API (0.1.0) from BetterAchievements-1.7.10-0.1.0.jar
		* BetterQuesting|API (3.2) from BetterQuesting-1.7.10-3.0.355-GTNH.jar
		* BetterQuesting|API2 (3.1) from BetterQuesting-1.7.10-3.0.355-GTNH.jar
		* BiomesOPlentyAPI (1.0.0) from BiomesOPlenty-1.7.10-2.1.3-GTNH.jar
		* BloodMagicAPI (1.3.3-13) from BloodMagic-1.7.10-1.3.8.jar
		* BotaniaAPI (76) from Botania-1.7.10-1.9.3-GTNH-pre.jar
		* BuildCraftAPI|blocks (1.0) from buildcraft-1.7.10-7.1.27.jar
		* BuildCraftAPI|blueprints (1.5) from buildcraft-1.7.10-7.1.27.jar
		* BuildCraftAPI|boards (2.0) from buildcraft-1.7.10-7.1.27.jar
		* BuildCraftAPI|core (1.0) from buildcraft-1.7.10-7.1.27.jar
		* BuildCraftAPI|crops (1.1) from buildcraft-1.7.10-7.1.27.jar
		* BuildCraftAPI|events (2.0) from buildcraft-1.7.10-7.1.27.jar
		* BuildCraftAPI|facades (1.1) from buildcraft-1.7.10-7.1.27.jar
		* BuildCraftAPI|filler (4.0) from buildcraft-1.7.10-7.1.27.jar
		* BuildCraftAPI|fuels (2.0) from buildcraft-1.7.10-7.1.27.jar
		* BuildCraftAPI|gates (4.1) from buildcraft-1.7.10-7.1.27.jar
		* BuildCraftAPI|items (1.1) from buildcraft-1.7.10-7.1.27.jar
		* BuildCraftAPI|library (2.0) from buildcraft-1.7.10-7.1.27.jar
		* BuildCraftAPI|lists (1.0) from buildcraft-1.7.10-7.1.27.jar
		* BuildCraftAPI|power (1.3) from buildcraft-1.7.10-7.1.27.jar
		* BuildCraftAPI|recipes (3.1) from buildcraft-1.7.10-7.1.27.jar
		* BuildCraftAPI|robotics (3.0) from buildcraft-1.7.10-7.1.27.jar
		* BuildCraftAPI|statements (1.1) from buildcraft-1.7.10-7.1.27.jar
		* BuildCraftAPI|tablet (1.0) from buildcraft-1.7.10-7.1.27.jar
		* BuildCraftAPI|tiles (1.2) from buildcraft-1.7.10-7.1.27.jar
		* BuildCraftAPI|tools (1.0) from extrautilities-1.2.13a.jar
		* BuildCraftAPI|transport (4.1) from buildcraft-1.7.10-7.1.27.jar
		* CarpentersBlocks|API (3.3.7) from Carpenter's Blocks v3.3.8.2 - MC 1.7.10.jar
		* ChiselAPI (0.1.1) from chisel-1.7.10-2.10.9-GTNH.jar
		* ChiselAPI|Carving (0.1.1) from chisel-1.7.10-2.10.9-GTNH.jar
		* ChiselAPI|Rendering (0.1.1) from chisel-1.7.10-2.10.9-GTNH.jar
		* CoFHAPI (1.7.10R1.0.13B2) from CoFHLib-[1.7.10]1.2.1-185.jar
		* CoFHAPI|block (1.7.10R1.0.13B2) from CoFHLib-[1.7.10]1.2.1-185.jar
		* CoFHAPI|core (1.7.10R1.0.13B2) from CoFHLib-[1.7.10]1.2.1-185.jar
		* CoFHAPI|energy (1.7.10R1.0.2) from GraviSuite-1.7.10-2.0.68u.jar
		* CoFHAPI|fluid (1.7.10R1.3.1) from CoFHCore-[1.7.10]3.1.4-329.jar
		* CoFHAPI|inventory (1.7.10R1.3.1) from CoFHCore-[1.7.10]3.1.4-329.jar
		* CoFHAPI|item (1.7.10R1.0.13B2) from CoFHLib-[1.7.10]1.2.1-185.jar
		* CoFHAPI|modhelpers (1.7.10R1.0.13B2) from CoFHLib-[1.7.10]1.2.1-185.jar
		* CoFHAPI|tileentity (1.7.10R1.0.13B2) from CoFHLib-[1.7.10]1.2.1-185.jar
		* CoFHAPI|transport (1.7.10R1.0.13B2) from CoFHLib-[1.7.10]1.2.1-185.jar
		* CoFHAPI|world (1.7.10R1.3.1) from CoFHCore-[1.7.10]3.1.4-329.jar
		* CoFHLib (1.7.10R1.2.1) from CoFHCore-[1.7.10]3.1.4-329.jar
		* CoFHLib|audio (1.7.10R1.0.3B3) from CoFHLib-[1.7.10]1.2.1-185.jar
		* CoFHLib|gui (1.7.10R1.2.1) from CoFHCore-[1.7.10]3.1.4-329.jar
		* CoFHLib|gui|container (1.7.10R1.2.1) from CoFHCore-[1.7.10]3.1.4-329.jar
		* CoFHLib|gui|element (1.7.10R1.2.1) from CoFHCore-[1.7.10]3.1.4-329.jar
		* CoFHLib|gui|element|listbox (1.7.10R1.2.1) from CoFHCore-[1.7.10]3.1.4-329.jar
		* CoFHLib|gui|slot (1.7.10R1.0.3B3) from CoFHLib-[1.7.10]1.2.1-185.jar
		* CoFHLib|inventory (1.7.10R1.0.3B3) from CoFHLib-[1.7.10]1.2.1-185.jar
		* CoFHLib|render (1.7.10R1.2.1) from CoFHCore-[1.7.10]3.1.4-329.jar
		* CoFHLib|render|particle (1.7.10R1.2.1) from CoFHCore-[1.7.10]3.1.4-329.jar
		* CoFHLib|util (1.7.10R1.2.1) from CoFHCore-[1.7.10]3.1.4-329.jar
		* CoFHLib|util|helpers (1.7.10R1.0.3B3) from CoFHLib-[1.7.10]1.2.1-185.jar
		* CoFHLib|util|position (1.7.10R1.2.1) from CoFHCore-[1.7.10]3.1.4-329.jar
		* CoFHLib|world (1.7.10R1.2.1) from CoFHCore-[1.7.10]3.1.4-329.jar
		* CoFHLib|world|feature (1.7.10R1.0.3B3) from CoFHLib-[1.7.10]1.2.1-185.jar
		* computronicsAPI (1.3) from Computronics-1.7.10-1.6.11-GTNH.jar
		* computronicsAPI|audio (1.0) from Computronics-1.7.10-1.6.11-GTNH.jar
		* computronicsAPI|chat (1.3) from Computronics-1.7.10-1.6.11-GTNH.jar
		* computronicsAPI|multiperipheral (1.1) from Computronics-1.7.10-1.6.11-GTNH.jar
		* computronicsAPI|tape (1.0) from Computronics-1.7.10-1.6.11-GTNH.jar
		* DraconicEvolution|API (1.2) from Draconic-Evolution-1.7.10-1.1.1.jar
		* DualWield (0.1) from battlegear2-1.7.10-1.1.1.8.jar
		* EnderIOAPI (0.0.2) from EnderIO-1.7.10-2.3.1.31.jar
		* EnderIOAPI|Redstone (0.0.2) from EnderIO-1.7.10-2.3.1.31.jar
		* EnderIOAPI|Teleport (0.0.2) from EnderIO-1.7.10-2.3.1.31.jar
		* EnderIOAPI|Tools (0.0.2) from EnderIO-1.7.10-2.3.1.31.jar
		* ForestryAPI|apiculture (5.0.0) from Forestry-1.7.10-4.4.6.jar
		* ForestryAPI|arboriculture (4.2.1) from Forestry-1.7.10-4.4.6.jar
		* ForestryAPI|circuits (3.1.0) from Forestry-1.7.10-4.4.6.jar
		* ForestryAPI|core (5.0.0) from Forestry-1.7.10-4.4.6.jar
		* ForestryAPI|farming (2.1.0) from Forestry-1.7.10-4.4.6.jar
		* ForestryAPI|food (1.1.0) from Forestry-1.7.10-4.4.6.jar
		* ForestryAPI|fuels (2.0.1) from Forestry-1.7.10-4.4.6.jar
		* ForestryAPI|genetics (4.7.1) from Forestry-1.7.10-4.4.6.jar
		* ForestryAPI|hives (4.1.0) from Forestry-1.7.10-4.4.6.jar
		* ForestryAPI|lepidopterology (1.3.0) from Forestry-1.7.10-4.4.6.jar
		* ForestryAPI|mail (3.0.0) from Forestry-1.7.10-4.4.6.jar
		* ForestryAPI|multiblock (3.0.0) from Forestry-1.7.10-4.4.6.jar
		* ForestryAPI|recipes (5.4.0) from Forestry-1.7.10-4.4.6.jar
		* ForestryAPI|storage (3.0.0) from Forestry-1.7.10-4.4.6.jar
		* ForestryAPI|world (2.1.0) from Forestry-1.7.10-4.4.6.jar
		* ForgeRelocation|API (0.0.1.4) from ForgeRelocation-0.0.1.4-universal.jar
		* Galacticraft API (1.0) from Galacticraft-1.7.10-3.0.40-GTNH.jar
		* gendustryAPI (2.3.0) from gendustry-1.7.10-1.6.5.3-GTNH.jar
		* Heraldry (alpha) from battlegear2-1.7.10-1.1.1.8.jar
		* IC2API (1.0) from industrialcraft-2-2.2.828a-experimental.jar
		* NuclearControlAPI (v1.0.5) from IC2NuclearControl-1.7.10-2.4.8.jar
		* OilTweakAPI (1.0.0) from BuildCraftOilTweak-1.7.10-1.0.3.jar
		* OilTweakAPI|blacklist (1.0.0) from BuildCraftOilTweak-1.7.10-1.0.3.jar
		* OpenBlocks|API (1.1) from OpenBlocks-1.7.10-1.6.8-GTNH.jar
		* OpenComputersAPI|Component (6.0.0-alpha) from OpenComputers-1.7.10-1.7.5.24-GTNH.jar
		* OpenComputersAPI|Core (6.0.0-alpha) from OpenComputers-1.7.10-1.7.5.24-GTNH.jar
		* OpenComputersAPI|Driver (6.0.0-alpha) from OpenComputers-1.7.10-1.7.5.24-GTNH.jar
		* OpenComputersAPI|Driver|Item (6.0.0-alpha) from OpenComputers-1.7.10-1.7.5.24-GTNH.jar
		* OpenComputersAPI|Event (6.0.0-alpha) from OpenComputers-1.7.10-1.7.5.24-GTNH.jar
		* OpenComputersAPI|FileSystem (6.0.0-alpha) from OpenComputers-1.7.10-1.7.5.24-GTNH.jar
		* OpenComputersAPI|Internal (6.0.0-alpha) from OpenComputers-1.7.10-1.7.5.24-GTNH.jar
		* OpenComputersAPI|Machine (6.0.0-alpha) from OpenComputers-1.7.10-1.7.5.24-GTNH.jar
		* OpenComputersAPI|Manual (6.0.0-alpha) from OpenComputers-1.7.10-1.7.5.24-GTNH.jar
		* OpenComputersAPI|Network (6.0.0-alpha) from OpenComputers-1.7.10-1.7.5.24-GTNH.jar
		* OpenComputersAPI|Prefab (6.0.0-alpha) from OpenComputers-1.7.10-1.7.5.24-GTNH.jar
		* Quiver (0.2) from battlegear2-1.7.10-1.1.1.8.jar
		* RailcraftAPI|bore (1.0.0) from Railcraft-1.7.10-9.13.7-pre.dirty.jar
		* RailcraftAPI|carts (1.6.0) from Railcraft-1.7.10-9.13.7-pre.dirty.jar
		* RailcraftAPI|core (1.5.0) from Railcraft-1.7.10-9.13.7-pre.dirty.jar
		* RailcraftAPI|crafting (1.0.0) from Railcraft-1.7.10-9.13.7-pre.dirty.jar
		* RailcraftAPI|electricity (2.0.0) from Railcraft-1.7.10-9.13.7-pre.dirty.jar
		* RailcraftAPI|events (1.0.0) from Railcraft-1.7.10-9.13.7-pre.dirty.jar
		* RailcraftAPI|fuel (1.0.0) from Railcraft-1.7.10-9.13.7-pre.dirty.jar
		* RailcraftAPI|helpers (1.1.0) from Railcraft-1.7.10-9.13.7-pre.dirty.jar
		* RailcraftAPI|items (1.0.0) from Railcraft-1.7.10-9.13.7-pre.dirty.jar
		* RailcraftAPI|locomotive (1.1.0) from Railcraft-1.7.10-9.13.7-pre.dirty.jar
		* RailcraftAPI|signals (2.3.0) from Railcraft-1.7.10-9.13.7-pre.dirty.jar
		* RailcraftAPI|tracks (2.3.0) from Railcraft-1.7.10-9.13.7-pre.dirty.jar
		* SchematicaAPI (1.1) from Schematica-1.7.10-1.8.5-GTNH.jar
		* SchematicaAPI|Events (1.1) from Schematica-1.7.10-1.8.5-GTNH.jar
		* Shield (0.1) from battlegear2-1.7.10-1.1.1.8.jar
		* StorageDrawersAPI (1.7.10-1.2.0) from StorageDrawers-1.7.10-1.11.13-GTNH.jar
		* StorageDrawersAPI|config (1.7.10-1.2.0) from StorageDrawers-1.7.10-1.11.13-GTNH.jar
		* StorageDrawersAPI|event (1.7.10-1.2.0) from StorageDrawers-1.7.10-1.11.13-GTNH.jar
		* StorageDrawersAPI|inventory (1.7.10-1.2.0) from StorageDrawers-1.7.10-1.11.13-GTNH.jar
		* StorageDrawersAPI|pack (1.7.10-1.2.0) from StorageDrawers-1.7.10-1.11.13-GTNH.jar
		* StorageDrawersAPI|registry (1.7.10-1.2.0) from StorageDrawers-1.7.10-1.11.13-GTNH.jar
		* StorageDrawersAPI|render (1.7.10-1.2.0) from StorageDrawers-1.7.10-1.11.13-GTNH.jar
		* StorageDrawersAPI|storage (1.7.10-1.2.0) from StorageDrawers-1.7.10-1.11.13-GTNH.jar
		* StorageDrawersAPI|storage-attribute (1.7.10-1.2.0) from StorageDrawers-1.7.10-1.11.13-GTNH.jar
		* Thaumcraft|API (4.2.2.0) from Thaumcraft-1.7.10-4.2.3.5.jar
		* thaumicenergistics|API (1.1) from thaumicenergistics-1.7.10-1.3.16-GTNH.jar
		* TravellersGear|API (1.0) from TravellersGear-1.7.10-1.16.8-GTNH.jar
		* WailaAPI (1.2) from Waila-1.7.10-1.5.20.jar
		* Weapons (0.1) from battlegear2-1.7.10-1.1.1.8.jar
	Chisel: Errors like "[FML]: Unable to lookup ..." are NOT the cause of this crash. You can safely ignore these errors. And update forge while you're at it.
	EnderIO: No known problems detected.
	Stencil buffer state: Function set: GL30, pool: forge, bits: 8
	Forestry : Info: The following plugins have been disabled in the config: magicalcrops
	AE2 Integration: IC2:ON, RotaryCraft:OFF, RC:ON, BuildCraftCore:ON, BuildCraftTransport:ON, BuildCraftBuilder:ON, RF:ON, RFItem:ON, MFR:OFF, DSU:ON, FZ:OFF, FMP:ON, RB:OFF, CLApi:OFF, Waila:ON, InvTweaks:ON, NEI:ON, CraftGuide:OFF, Mekanism:OFF, ImmibisMicroblocks:OFF, BetterStorage:OFF, OpenComputers:ON, PneumaticCraft:OFF, GT:ON, Chisel:ON, Jabba:ON
	Launched Version: MultiMC5
	LWJGL: 2.9.4
	OpenGL: GeForce GTX 1060 6GB/PCIe/SSE2 GL version 4.6.0 NVIDIA 456.71, NVIDIA Corporation
	GL Caps: Using GL 1.3 multitexturing.
Using framebuffer objects because OpenGL 3.0 is supported and separate blending is supported.
Anisotropic filtering is supported and maximum anisotropy is 16.
Shaders are available because OpenGL 2.1 is supported.

	Is Modded: Definitely; Client brand changed to 'fml,forge'
	Type: Client (map_client.txt)
	Resource Packs: []
	Current Language: English (US)
	Profiler Position: N/A (disabled)
	Vec3 Pool Size: 0 (0 bytes; 0 MB) allocated, 0 (0 bytes; 0 MB) used
	Anisotropic Filtering: Off (1)
</details>