### PR TITLE
Add option to cache item grid rendering

### DIFF
--- a/src/main/java/codechicken/nei/BookmarkPanel.java
+++ b/src/main/java/codechicken/nei/BookmarkPanel.java
@@ -98,11 +98,13 @@ public class BookmarkPanel extends PanelWidget
         {
             realItems.add(stackA);
             metadata.add(meta);
+            refreshBuffer = true;
         }
 
         public void replaceItem(int idx, ItemStack stack)
         {
             realItems.set(idx, stack);
+            refreshBuffer = true;
         }
 
         public void removeRecipe(int idx, boolean removeFullRecipe)
@@ -136,6 +138,7 @@ public class BookmarkPanel extends PanelWidget
         {
             realItems.remove(idx);
             metadata.remove(idx);
+            refreshBuffer = true;
             return true;
         }
 
@@ -161,40 +164,40 @@ public class BookmarkPanel extends PanelWidget
         {
             realItems.add(dst, realItems.remove(src));
             metadata.add(dst, metadata.remove(src));
+            refreshBuffer = true;
+        }
+
+        @Override
+        protected void drawFocusOutline(ItemPanelSlot focus, int idx, Rectangle4i rect) {
+            if(LayoutManager.bookmarkPanel.sortedNamespaceIndex == LayoutManager.bookmarkPanel.activeNamespaceIndex && LayoutManager.bookmarkPanel.sortedStackIndex == idx) {
+                drawRect(rect.x, rect.y, rect.w, rect.h, 0xee555555);//highlight
+                return;
+            }
+            BookmarkStackMeta meta = getMetadata(idx);
+            if (
+                    LayoutManager.bookmarkPanel.sortedStackIndex == -1 && //disabled when sorting
+                            NEIClientUtils.shiftKey() &&  //show only with shift key
+                            getRecipeId(focus.slotIndex) != null
+            ) {
+                drawRect(rect.x, rect.y, rect.w, rect.h, meta.ingredient? 0x88b3b300: 0x88009933);//highlight recipe
+            } else {
+                drawRect(rect.x, rect.y, rect.w, rect.h, 0xee555555);//highlight
+            }
         }
 
         @Override
         protected void drawItem(Rectangle4i rect, int idx, ItemPanelSlot focus)
         {
-
-            if (LayoutManager.bookmarkPanel.sortedNamespaceIndex == LayoutManager.bookmarkPanel.activeNamespaceIndex && LayoutManager.bookmarkPanel.sortedStackIndex == idx) {
-                drawRect(rect.x, rect.y, rect.w, rect.h, 0xee555555);//highlight
-            } else {
+            if (LayoutManager.bookmarkPanel.sortedNamespaceIndex != LayoutManager.bookmarkPanel.activeNamespaceIndex || LayoutManager.bookmarkPanel.sortedStackIndex != idx) {
                 final ItemStack stack = getItem(idx);
                 final BookmarkStackMeta meta = getMetadata(idx);
-
-                if (focus != null) {
-
-                    if (
-                            LayoutManager.bookmarkPanel.sortedStackIndex == -1 && //disabled when sorting
-                            NEIClientUtils.shiftKey() &&  //show only with shift key
-                            getRecipeId(focus.slotIndex) != null && getRecipeId(idx) != null && getRecipeId(focus.slotIndex).equals(getRecipeId(idx))//is some recipeId
-                    ) {
-                        drawRect(rect.x, rect.y, rect.w, rect.h, meta.ingredient? 0x88b3b300: 0x88009933);//highlight recipe
-                    } else if (focus.slotIndex == idx) {
-                        drawRect(rect.x, rect.y, rect.w, rect.h, 0xee555555);//highlight
-                    }
-
-                }
 
                 GuiContainerManager.drawItem(rect.x + 1, rect.y + 1, stack, true, meta.factor < 0 || meta.fluidDisplay? "": String.valueOf(stack.stackSize));
 
                 if (meta.recipeId != null && !meta.ingredient && NEIClientConfig.showRecipeMarker()) {
                     drawRecipeMarker(rect.x, rect.y, GuiContainerManager.getFontRenderer(stack));
                 }
-
             }
-
         }
 
         protected void drawRecipeMarker(int offsetX, int offsetY, FontRenderer fontRenderer )

--- a/src/main/java/codechicken/nei/BookmarkPanel.java
+++ b/src/main/java/codechicken/nei/BookmarkPanel.java
@@ -168,7 +168,14 @@ public class BookmarkPanel extends PanelWidget
         }
 
         @Override
-        protected void drawFocusOutline(ItemPanelSlot focus, int idx, Rectangle4i rect) {
+        protected boolean slotNeedsOutline(ItemPanelSlot focused, int idx) {
+            return super.slotNeedsOutline(focused, idx)
+                    || (getRecipeId(focused.slotIndex) != null && getRecipeId(idx) != null && getRecipeId(focused.slotIndex).equals(getRecipeId(idx)))
+                    || (LayoutManager.bookmarkPanel.sortedNamespaceIndex == LayoutManager.bookmarkPanel.activeNamespaceIndex && LayoutManager.bookmarkPanel.sortedStackIndex == idx);
+        }
+
+        @Override
+        protected void drawSlotOutline(ItemPanelSlot focus, int idx, Rectangle4i rect) {
             if(LayoutManager.bookmarkPanel.sortedNamespaceIndex == LayoutManager.bookmarkPanel.activeNamespaceIndex && LayoutManager.bookmarkPanel.sortedStackIndex == idx) {
                 drawRect(rect.x, rect.y, rect.w, rect.h, 0xee555555);//highlight
                 return;

--- a/src/main/java/codechicken/nei/BookmarkPanel.java
+++ b/src/main/java/codechicken/nei/BookmarkPanel.java
@@ -193,7 +193,7 @@ public class BookmarkPanel extends PanelWidget
         }
 
         @Override
-        protected void drawItem(Rectangle4i rect, int idx, ItemPanelSlot focus)
+        protected void drawItem(Rectangle4i rect, int idx)
         {
             if (LayoutManager.bookmarkPanel.sortedNamespaceIndex != LayoutManager.bookmarkPanel.activeNamespaceIndex || LayoutManager.bookmarkPanel.sortedStackIndex != idx) {
                 final ItemStack stack = getItem(idx);

--- a/src/main/java/codechicken/nei/BookmarkPanel.java
+++ b/src/main/java/codechicken/nei/BookmarkPanel.java
@@ -179,13 +179,6 @@ public class BookmarkPanel extends PanelWidget
         }
 
         @Override
-        protected boolean slotNeedsOutline(@Nullable ItemPanelSlot focused, int idx) {
-            return super.slotNeedsOutline(focused, idx)
-                    || isPartOfFocusedRecipe(focused, idx)
-                    || (LayoutManager.bookmarkPanel.sortedNamespaceIndex == LayoutManager.bookmarkPanel.activeNamespaceIndex && LayoutManager.bookmarkPanel.sortedStackIndex == idx);
-        }
-
-        @Override
         protected void drawSlotOutline(@Nullable ItemPanelSlot focus, int idx, Rectangle4i rect) {
             if(LayoutManager.bookmarkPanel.sortedNamespaceIndex == LayoutManager.bookmarkPanel.activeNamespaceIndex && LayoutManager.bookmarkPanel.sortedStackIndex == idx) {
                 drawRect(rect.x, rect.y, rect.w, rect.h, 0xee555555);//highlight
@@ -193,7 +186,7 @@ public class BookmarkPanel extends PanelWidget
                 BookmarkStackMeta meta = getMetadata(idx);
                 if (isPartOfFocusedRecipe(focus, idx)) {
                     drawRect(rect.x, rect.y, rect.w, rect.h, meta.ingredient? 0x88b3b300: 0x88009933);//highlight recipe
-                } else {
+                } else if(focus.slotIndex == idx) {
                     drawRect(rect.x, rect.y, rect.w, rect.h, 0xee555555);//highlight
                 }
             }

--- a/src/main/java/codechicken/nei/BookmarkPanel.java
+++ b/src/main/java/codechicken/nei/BookmarkPanel.java
@@ -19,6 +19,8 @@ import net.minecraft.nbt.NBTTagCompound;
 import org.apache.commons.io.IOUtils;
 import org.lwjgl.opengl.GL11;
 
+import javax.annotation.Nullable;
+
 import static codechicken.lib.gui.GuiDraw.getMousePosition;
 import static codechicken.lib.gui.GuiDraw.drawRect;
 
@@ -167,28 +169,33 @@ public class BookmarkPanel extends PanelWidget
             refreshBuffer = true;
         }
 
+        private boolean isPartOfFocusedRecipe(ItemPanelSlot focused, int myIdx) {
+            return (NEIClientUtils.shiftKey()
+                && LayoutManager.bookmarkPanel.sortedStackIndex == -1
+                && focused != null
+                && getRecipeId(focused.slotIndex) != null
+                && getRecipeId(myIdx) != null
+                && getRecipeId(focused.slotIndex).equals(getRecipeId(myIdx)));
+        }
+
         @Override
-        protected boolean slotNeedsOutline(ItemPanelSlot focused, int idx) {
+        protected boolean slotNeedsOutline(@Nullable ItemPanelSlot focused, int idx) {
             return super.slotNeedsOutline(focused, idx)
-                    || (getRecipeId(focused.slotIndex) != null && getRecipeId(idx) != null && getRecipeId(focused.slotIndex).equals(getRecipeId(idx)))
+                    || isPartOfFocusedRecipe(focused, idx)
                     || (LayoutManager.bookmarkPanel.sortedNamespaceIndex == LayoutManager.bookmarkPanel.activeNamespaceIndex && LayoutManager.bookmarkPanel.sortedStackIndex == idx);
         }
 
         @Override
-        protected void drawSlotOutline(ItemPanelSlot focus, int idx, Rectangle4i rect) {
+        protected void drawSlotOutline(@Nullable ItemPanelSlot focus, int idx, Rectangle4i rect) {
             if(LayoutManager.bookmarkPanel.sortedNamespaceIndex == LayoutManager.bookmarkPanel.activeNamespaceIndex && LayoutManager.bookmarkPanel.sortedStackIndex == idx) {
                 drawRect(rect.x, rect.y, rect.w, rect.h, 0xee555555);//highlight
-                return;
-            }
-            BookmarkStackMeta meta = getMetadata(idx);
-            if (
-                    LayoutManager.bookmarkPanel.sortedStackIndex == -1 && //disabled when sorting
-                            NEIClientUtils.shiftKey() &&  //show only with shift key
-                            getRecipeId(focus.slotIndex) != null
-            ) {
-                drawRect(rect.x, rect.y, rect.w, rect.h, meta.ingredient? 0x88b3b300: 0x88009933);//highlight recipe
-            } else {
-                drawRect(rect.x, rect.y, rect.w, rect.h, 0xee555555);//highlight
+            } else if(focus != null) {
+                BookmarkStackMeta meta = getMetadata(idx);
+                if (isPartOfFocusedRecipe(focus, idx)) {
+                    drawRect(rect.x, rect.y, rect.w, rect.h, meta.ingredient? 0x88b3b300: 0x88009933);//highlight recipe
+                } else {
+                    drawRect(rect.x, rect.y, rect.w, rect.h, 0xee555555);//highlight
+                }
             }
         }
 

--- a/src/main/java/codechicken/nei/BookmarkPanel.java
+++ b/src/main/java/codechicken/nei/BookmarkPanel.java
@@ -767,6 +767,7 @@ public class BookmarkPanel extends PanelWidget
                 if (stack != null && (mouseOverSlot == null || mouseOverSlot.slotIndex != mouseDownSlot || heldTime > 250)) {
                     sortedNamespaceIndex = activeNamespaceIndex;
                     sortedStackIndex = mouseDownSlot;
+                    grid.refreshBuffer = true;
                 }
 
             } else {
@@ -847,6 +848,7 @@ public class BookmarkPanel extends PanelWidget
             sortedNamespaceIndex = -1;
             sortedStackIndex = -1;
             mouseDownSlot = -1;
+            grid.refreshBuffer = true; /* make sure grid redraws the new item */
             saveBookmarks();
         } else {
             super.mouseUp(mousex, mousey, button);

--- a/src/main/java/codechicken/nei/ItemPanel.java
+++ b/src/main/java/codechicken/nei/ItemPanel.java
@@ -4,6 +4,8 @@ import codechicken.lib.vec.Rectangle4i;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 
+import javax.annotation.Nullable;
+
 import static codechicken.lib.gui.GuiDraw.drawRect;
 
 import java.util.ArrayList;
@@ -74,17 +76,14 @@ public class ItemPanel extends PanelWidget
         }
 
         @Override
-        protected void drawItem(Rectangle4i rect, int idx, ItemPanelSlot focus)
-        {
-
-            if (PresetsWidget.inEditMode() && !PresetsWidget.isHidden(getItem(idx))) {
-                drawRect(rect.x, rect.y, rect.w, rect.h, 0xee555555);
+        protected void drawSlotOutline(@Nullable ItemPanelSlot focused, int slotIdx, Rectangle4i rect) {
+            if (PresetsWidget.inEditMode()) {
+                if(!PresetsWidget.isHidden(getItem(slotIdx)))
+                    drawRect(rect.x, rect.y, rect.w, rect.h, 0xee555555);
+            } else {
+                super.drawSlotOutline(focused, slotIdx, rect);
             }
-
-            super.drawItem(rect, idx, PresetsWidget.inEditMode()? null: focus);
         }
-
-
     }
 
     public ItemPanel()

--- a/src/main/java/codechicken/nei/ItemPanel.java
+++ b/src/main/java/codechicken/nei/ItemPanel.java
@@ -67,6 +67,7 @@ public class ItemPanel extends PanelWidget
             if (newItems != null) {
                 realItems = newItems;
                 newItems = null;
+                refreshBuffer = true;
             }
 
             super.refresh(gui);

--- a/src/main/java/codechicken/nei/ItemsGrid.java
+++ b/src/main/java/codechicken/nei/ItemsGrid.java
@@ -203,8 +203,12 @@ public class ItemsGrid
             if(invalidSlotMap[pageIdx])
                 return;
             Rectangle4i rect = getSlotRect(pageIdx);
-            drawRect(rect.x, rect.y, rect.w, rect.h, 0xee555555);//highlight
+            drawFocusOutline(slot, pageIdx, rect);
         }
+    }
+
+    protected void drawFocusOutline(ItemPanelSlot slot, int idx, Rectangle4i rect) {
+        drawRect(rect.x, rect.y, rect.w, rect.h, 0xee555555);//highlight
     }
 
     public void draw(int mousex, int mousey)

--- a/src/main/java/codechicken/nei/ItemsGrid.java
+++ b/src/main/java/codechicken/nei/ItemsGrid.java
@@ -240,8 +240,6 @@ public class ItemsGrid
             return;
         }
 
-        ItemPanelSlot slot = getSlotMouseOver(mousex, mousey);
-
         boolean shouldCache = NEIClientConfig.shouldCacheItemRendering() && !PresetsWidget.inEditMode();
         if(shouldCache) {
             Minecraft minecraft = Minecraft.getMinecraft();
@@ -274,7 +272,7 @@ public class ItemsGrid
         int idx = page * perPage;
         for (int i = 0; i < rows * columns && idx < size(); i++) {
             if (!invalidSlotMap[i]) {
-                drawItem(getSlotRect(i), idx, slot);
+                drawItem(getSlotRect(i), idx);
                 idx ++;
             }
         }
@@ -288,7 +286,7 @@ public class ItemsGrid
         }
     }
 
-    protected void drawItem(Rectangle4i rect, int idx, ItemPanelSlot focus)
+    protected void drawItem(Rectangle4i rect, int idx)
     {
         GuiContainerManager.drawItem(rect.x + 1, rect.y + 1, getItem(idx));
     }

--- a/src/main/java/codechicken/nei/ItemsGrid.java
+++ b/src/main/java/codechicken/nei/ItemsGrid.java
@@ -256,7 +256,6 @@ public class ItemsGrid
                 framebuffer.framebufferColor[2] = 0.0F;
             }
             drawFocusOutline(mousex, mousey);
-            blitExistingBuffer();
             if (refreshBuffer) {
                 framebuffer.createBindFramebuffer(minecraft.displayWidth, minecraft.displayHeight);
                 framebuffer.framebufferClear();
@@ -267,6 +266,7 @@ public class ItemsGrid
                 OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
                 GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
             } else {
+                blitExistingBuffer();
                 return;
             }
         } else {
@@ -288,6 +288,7 @@ public class ItemsGrid
         if (refreshBuffer && shouldCache) {
             refreshBuffer = false;
             Minecraft.getMinecraft().getFramebuffer().bindFramebuffer(false);
+            blitExistingBuffer();
         }
     }
 

--- a/src/main/java/codechicken/nei/ItemsGrid.java
+++ b/src/main/java/codechicken/nei/ItemsGrid.java
@@ -198,12 +198,17 @@ public class ItemsGrid
     private void drawFocusOutline(int mousex, int mousey)
     {
         ItemPanelSlot slot = getSlotMouseOver(mousex, mousey);
-        if (slot != null) {
-            int pageIdx = slot.slotIndex % perPage;
-            if(invalidSlotMap[pageIdx])
-                return;
-            Rectangle4i rect = getSlotRect(pageIdx);
-            drawFocusOutline(slot, pageIdx, rect);
+        if(slot == null)
+            return;
+        int idx = page * perPage;
+        for (int i = 0; i < rows * columns && idx < size(); i++) {
+            if(!invalidSlotMap[i]) {
+                if(slot.slotIndex == idx) {
+                    drawFocusOutline(slot, idx, getSlotRect(i));
+                    break;
+                }
+                idx++;
+            }
         }
     }
 

--- a/src/main/java/codechicken/nei/ItemsGrid.java
+++ b/src/main/java/codechicken/nei/ItemsGrid.java
@@ -216,6 +216,24 @@ public class ItemsGrid
         drawRect(rect.x, rect.y, rect.w, rect.h, 0xee555555);//highlight
     }
 
+    private void blitExistingBuffer() {
+        Minecraft minecraft = Minecraft.getMinecraft();
+        GL11.glEnable(GL11.GL_BLEND);
+        OpenGlHelper.glBlendFunc(GL11.GL_ONE, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_ONE, GL11.GL_ONE_MINUS_SRC_ALPHA);
+        GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+        framebuffer.bindFramebufferTexture();
+        GL11.glEnable(GL11.GL_TEXTURE_2D);
+        ScaledResolution res = new ScaledResolution(minecraft, minecraft.displayWidth, minecraft.displayHeight);
+        Tessellator tessellator = Tessellator.instance;
+        tessellator.startDrawingQuads();
+        tessellator.addVertexWithUV(0, res.getScaledHeight_double(), 0.0, 0, 0);
+        tessellator.addVertexWithUV(res.getScaledWidth_double(), res.getScaledHeight_double(), 0.0, 1, 0);
+        tessellator.addVertexWithUV(res.getScaledWidth_double(), 0, 0.0, 1, 1);
+        tessellator.addVertexWithUV(0, 0, 0, 0, 1);
+        tessellator.draw();
+        OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_ONE, GL11.GL_ZERO);
+    }
+
     public void draw(int mousex, int mousey)
     {
         if (getPerPage() == 0) {
@@ -233,6 +251,8 @@ public class ItemsGrid
                 framebuffer.framebufferColor[1] = 0.0F;
                 framebuffer.framebufferColor[2] = 0.0F;
             }
+            drawFocusOutline(mousex, mousey);
+            blitExistingBuffer();
             if (refreshBuffer) {
                 framebuffer.createBindFramebuffer(minecraft.displayWidth, minecraft.displayHeight);
                 framebuffer.framebufferClear();
@@ -243,21 +263,6 @@ public class ItemsGrid
                 OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
                 GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
             } else {
-                drawFocusOutline(mousex, mousey);
-                GL11.glEnable(GL11.GL_BLEND);
-                OpenGlHelper.glBlendFunc(GL11.GL_ONE, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_ONE, GL11.GL_ONE_MINUS_SRC_ALPHA);
-                GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-                framebuffer.bindFramebufferTexture();
-                GL11.glEnable(GL11.GL_TEXTURE_2D);
-                ScaledResolution res = new ScaledResolution(minecraft, minecraft.displayWidth, minecraft.displayHeight);
-                Tessellator tessellator = Tessellator.instance;
-                tessellator.startDrawingQuads();
-                tessellator.addVertexWithUV(0, res.getScaledHeight_double(), 0.0, 0, 0);
-                tessellator.addVertexWithUV(res.getScaledWidth_double(), res.getScaledHeight_double(), 0.0, 1, 0);
-                tessellator.addVertexWithUV(res.getScaledWidth_double(), 0, 0.0, 1, 1);
-                tessellator.addVertexWithUV(0, 0, 0, 0, 1);
-                tessellator.draw();
-                OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_ONE, GL11.GL_ZERO);
                 return;
             }
         } else {

--- a/src/main/java/codechicken/nei/ItemsGrid.java
+++ b/src/main/java/codechicken/nei/ItemsGrid.java
@@ -199,24 +199,27 @@ public class ItemsGrid
         return invalidSlotMap[idx];
     }
 
-    private void drawFocusOutline(int mousex, int mousey)
+    protected boolean slotNeedsOutline(ItemPanelSlot focused, int slotIdx) {
+        return focused.slotIndex == slotIdx;
+    }
+
+    private void drawSlotOutlines(int mousex, int mousey)
     {
-        ItemPanelSlot slot = getSlotMouseOver(mousex, mousey);
-        if(slot == null)
+        ItemPanelSlot focused = getSlotMouseOver(mousex, mousey);
+        if(focused == null)
             return;
         int idx = page * perPage;
         for (int i = 0; i < rows * columns && idx < size(); i++) {
             if(!invalidSlotMap[i]) {
-                if(slot.slotIndex == idx) {
-                    drawFocusOutline(slot, idx, getSlotRect(i));
-                    break;
+                if(slotNeedsOutline(focused, idx)) {
+                    drawSlotOutline(focused, idx, getSlotRect(i));
                 }
                 idx++;
             }
         }
     }
 
-    protected void drawFocusOutline(ItemPanelSlot slot, int idx, Rectangle4i rect) {
+    protected void drawSlotOutline(ItemPanelSlot focused, int slotIdx, Rectangle4i rect) {
         drawRect(rect.x, rect.y, rect.w, rect.h, 0xee555555);//highlight
     }
 
@@ -255,7 +258,7 @@ public class ItemsGrid
                 framebuffer.framebufferColor[1] = 0.0F;
                 framebuffer.framebufferColor[2] = 0.0F;
             }
-            drawFocusOutline(mousex, mousey);
+            drawSlotOutlines(mousex, mousey);
             if (refreshBuffer) {
                 framebuffer.createBindFramebuffer(minecraft.displayWidth, minecraft.displayHeight);
                 framebuffer.framebufferClear();
@@ -270,7 +273,7 @@ public class ItemsGrid
                 return;
             }
         } else {
-            drawFocusOutline(mousex, mousey);
+            drawSlotOutlines(mousex, mousey);
         }
 
         GuiContainerManager.enableMatrixStackLogging();

--- a/src/main/java/codechicken/nei/ItemsGrid.java
+++ b/src/main/java/codechicken/nei/ItemsGrid.java
@@ -220,7 +220,6 @@ public class ItemsGrid
         ItemPanelSlot slot = getSlotMouseOver(mousex, mousey);
 
         boolean shouldCache = NEIClientConfig.shouldCacheItemRendering() && !PresetsWidget.inEditMode();
-
         if(shouldCache) {
             Minecraft minecraft = Minecraft.getMinecraft();
             if (framebuffer == null) {
@@ -235,8 +234,8 @@ public class ItemsGrid
                 framebuffer.bindFramebuffer(false);
                 /* Set up some rendering state needed for items to work correctly */
                 GL11.glDisable(GL11.GL_BLEND);
-                GL11.glDepthMask(false);
-                OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_ONE, GL11.GL_ONE_MINUS_SRC_ALPHA);
+                GL11.glDepthMask(true);
+                OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
                 GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
             } else {
                 drawFocusOutline(mousex, mousey);

--- a/src/main/java/codechicken/nei/ItemsGrid.java
+++ b/src/main/java/codechicken/nei/ItemsGrid.java
@@ -199,15 +199,13 @@ public class ItemsGrid
         return invalidSlotMap[idx];
     }
 
-    protected boolean slotNeedsOutline(ItemPanelSlot focused, int slotIdx) {
-        return focused.slotIndex == slotIdx;
+    protected boolean slotNeedsOutline(@Nullable ItemPanelSlot focused, int slotIdx) {
+        return focused != null && focused.slotIndex == slotIdx;
     }
 
     private void drawSlotOutlines(int mousex, int mousey)
     {
         ItemPanelSlot focused = getSlotMouseOver(mousex, mousey);
-        if(focused == null)
-            return;
         int idx = page * perPage;
         for (int i = 0; i < rows * columns && idx < size(); i++) {
             if(!invalidSlotMap[i]) {
@@ -219,7 +217,7 @@ public class ItemsGrid
         }
     }
 
-    protected void drawSlotOutline(ItemPanelSlot focused, int slotIdx, Rectangle4i rect) {
+    protected void drawSlotOutline(@Nullable ItemPanelSlot focused, int slotIdx, Rectangle4i rect) {
         drawRect(rect.x, rect.y, rect.w, rect.h, 0xee555555);//highlight
     }
 

--- a/src/main/java/codechicken/nei/ItemsGrid.java
+++ b/src/main/java/codechicken/nei/ItemsGrid.java
@@ -5,9 +5,16 @@ import codechicken.nei.api.GuiInfo;
 import codechicken.nei.guihook.GuiContainerManager;
 import codechicken.nei.recipe.StackInfo;
 import codechicken.nei.ItemPanel.ItemPanelSlot;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.client.renderer.OpenGlHelper;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.shader.Framebuffer;
 import net.minecraft.item.ItemStack;
+import org.lwjgl.opengl.GL11;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 
 import static codechicken.lib.gui.GuiDraw.drawRect;
@@ -37,6 +44,10 @@ public class ItemsGrid
 
     protected boolean[] validSlotMap;
     protected boolean[] invalidSlotMap;
+
+    @Nullable
+    private Framebuffer framebuffer = null;
+    protected boolean refreshBuffer = true;
 
     public ArrayList<ItemStack> getItems()
     {
@@ -92,6 +103,8 @@ public class ItemsGrid
 
     public void setGridSize(int mleft, int mtop, int w, int h)
     {
+        if(width != w || height != h || mleft != marginLeft || mtop != marginTop)
+            refreshBuffer = true;
 
         marginLeft = mleft;
         marginTop = mtop;
@@ -126,6 +139,8 @@ public class ItemsGrid
         }
 
         page = Math.max(0, Math.min(page, numPages - 1));
+        if(shift != 0)
+            refreshBuffer = true;
     }
 
     public void refresh(GuiContainer gui)
@@ -180,6 +195,18 @@ public class ItemsGrid
         return invalidSlotMap[idx];
     }
 
+    private void drawFocusOutline(int mousex, int mousey)
+    {
+        ItemPanelSlot slot = getSlotMouseOver(mousex, mousey);
+        if (slot != null) {
+            int pageIdx = slot.slotIndex % perPage;
+            if(invalidSlotMap[pageIdx])
+                return;
+            Rectangle4i rect = getSlotRect(pageIdx);
+            drawRect(rect.x, rect.y, rect.w, rect.h, 0xee555555);//highlight
+        }
+    }
+
     public void draw(int mousex, int mousey)
     {
         if (getPerPage() == 0) {
@@ -188,28 +215,67 @@ public class ItemsGrid
 
         ItemPanelSlot slot = getSlotMouseOver(mousex, mousey);
 
+        boolean shouldCache = NEIClientConfig.shouldCacheItemRendering() && !PresetsWidget.inEditMode();
+
+        if(shouldCache) {
+            Minecraft minecraft = Minecraft.getMinecraft();
+            if (framebuffer == null) {
+                framebuffer = new Framebuffer(minecraft.displayWidth, minecraft.displayHeight, true);
+                framebuffer.framebufferColor[0] = 0.0F;
+                framebuffer.framebufferColor[1] = 0.0F;
+                framebuffer.framebufferColor[2] = 0.0F;
+            }
+            if (refreshBuffer) {
+                framebuffer.createBindFramebuffer(minecraft.displayWidth, minecraft.displayHeight);
+                framebuffer.framebufferClear();
+                framebuffer.bindFramebuffer(false);
+                /* Set up some rendering state needed for items to work correctly */
+                GL11.glDisable(GL11.GL_BLEND);
+                GL11.glDepthMask(false);
+                OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_ONE, GL11.GL_ONE_MINUS_SRC_ALPHA);
+                GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+            } else {
+                drawFocusOutline(mousex, mousey);
+                GL11.glEnable(GL11.GL_BLEND);
+                OpenGlHelper.glBlendFunc(GL11.GL_ONE, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_ONE, GL11.GL_ONE_MINUS_SRC_ALPHA);
+                GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+                framebuffer.bindFramebufferTexture();
+                GL11.glEnable(GL11.GL_TEXTURE_2D);
+                ScaledResolution res = new ScaledResolution(minecraft, minecraft.displayWidth, minecraft.displayHeight);
+                Tessellator tessellator = Tessellator.instance;
+                tessellator.startDrawingQuads();
+                tessellator.addVertexWithUV(0, res.getScaledHeight_double(), 0.0, 0, 0);
+                tessellator.addVertexWithUV(res.getScaledWidth_double(), res.getScaledHeight_double(), 0.0, 1, 0);
+                tessellator.addVertexWithUV(res.getScaledWidth_double(), 0, 0.0, 1, 1);
+                tessellator.addVertexWithUV(0, 0, 0, 0, 1);
+                tessellator.draw();
+                OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_ONE, GL11.GL_ZERO);
+                return;
+            }
+        } else {
+            drawFocusOutline(mousex, mousey);
+        }
+
         GuiContainerManager.enableMatrixStackLogging();
 
         int idx = page * perPage;
         for (int i = 0; i < rows * columns && idx < size(); i++) {
-
             if (!invalidSlotMap[i]) {
                 drawItem(getSlotRect(i), idx, slot);
                 idx ++;
             }
-
         }
 
         GuiContainerManager.disableMatrixStackLogging();
+
+        if (refreshBuffer && shouldCache) {
+            refreshBuffer = false;
+            Minecraft.getMinecraft().getFramebuffer().bindFramebuffer(false);
+        }
     }
 
     protected void drawItem(Rectangle4i rect, int idx, ItemPanelSlot focus)
     {
-
-        if (focus != null && focus.slotIndex == idx) {
-            drawRect(rect.x, rect.y, rect.w, rect.h, 0xee555555);//highlight
-        }
-
         GuiContainerManager.drawItem(rect.x + 1, rect.y + 1, getItem(idx));
     }
 

--- a/src/main/java/codechicken/nei/ItemsGrid.java
+++ b/src/main/java/codechicken/nei/ItemsGrid.java
@@ -199,26 +199,21 @@ public class ItemsGrid
         return invalidSlotMap[idx];
     }
 
-    protected boolean slotNeedsOutline(@Nullable ItemPanelSlot focused, int slotIdx) {
-        return focused != null && focused.slotIndex == slotIdx;
-    }
-
     private void drawSlotOutlines(int mousex, int mousey)
     {
         ItemPanelSlot focused = getSlotMouseOver(mousex, mousey);
         int idx = page * perPage;
         for (int i = 0; i < rows * columns && idx < size(); i++) {
             if(!invalidSlotMap[i]) {
-                if(slotNeedsOutline(focused, idx)) {
-                    drawSlotOutline(focused, idx, getSlotRect(i));
-                }
+                drawSlotOutline(focused, idx, getSlotRect(i));
                 idx++;
             }
         }
     }
 
     protected void drawSlotOutline(@Nullable ItemPanelSlot focused, int slotIdx, Rectangle4i rect) {
-        drawRect(rect.x, rect.y, rect.w, rect.h, 0xee555555);//highlight
+        if(focused != null && focused.slotIndex == slotIdx)
+            drawRect(rect.x, rect.y, rect.w, rect.h, 0xee555555);//highlight
     }
 
     private void blitExistingBuffer() {

--- a/src/main/java/codechicken/nei/ItemsGrid.java
+++ b/src/main/java/codechicken/nei/ItemsGrid.java
@@ -16,6 +16,7 @@ import org.lwjgl.opengl.GL11;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Arrays;
 
 import static codechicken.lib.gui.GuiDraw.drawRect;
 
@@ -151,12 +152,15 @@ public class ItemsGrid
 
     private void updateGuiOverlapSlots(GuiContainer gui)
     {
+        boolean[] oldSlotMap = invalidSlotMap;
         invalidSlotMap = new boolean[rows * columns];
         perPage = columns * rows;
 
         checkGuiOverlap(gui, 0, columns - 2, 1);
         checkGuiOverlap(gui, columns - 1, 1, -1);
-
+        if(NEIClientConfig.shouldCacheItemRendering() && !Arrays.equals(oldSlotMap, invalidSlotMap)) {
+            refreshBuffer = true;
+        }
     }
 
     private void checkGuiOverlap(GuiContainer gui, int start, int end, int dir)

--- a/src/main/java/codechicken/nei/NEIClientConfig.java
+++ b/src/main/java/codechicken/nei/NEIClientConfig.java
@@ -34,6 +34,7 @@ import codechicken.obfuscator.ObfuscationRun;
 import com.google.common.base.Objects;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
@@ -182,6 +183,9 @@ public class NEIClientConfig {
                 return isMouseScrollTransferEnabled();
             }
         });
+
+        tag.getTag("inventory.cacheItemRendering").getBooleanValue(false);
+        API.addOption(new OptionToggleButton("inventory.cacheItemRendering", true));
         
         tag.getTag("itemLoadingTimeout").getIntValue(500);
 
@@ -548,6 +552,10 @@ public class NEIClientConfig {
 
     public static boolean shouldInvertMouseScrollTransfer() {
         return !getBooleanSetting("inventory.invertMouseScrollTransfer");
+    }
+
+    public static boolean shouldCacheItemRendering() {
+        return getBooleanSetting("inventory.cacheItemRendering") && OpenGlHelper.framebufferSupported;
     }
 
     public static boolean getMagnetMode() {

--- a/src/main/java/codechicken/nei/NEIPotionGuiHandler.java
+++ b/src/main/java/codechicken/nei/NEIPotionGuiHandler.java
@@ -2,16 +2,13 @@ package codechicken.nei;
 
 import codechicken.lib.vec.Rectangle4i;
 import codechicken.nei.api.INEIGuiAdapter;
-import com.google.common.collect.Ordering;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.InventoryEffectRenderer;
-import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
 
 import java.util.Collection;
-import java.util.Collections;
 
 /**
  * Inspired by InventoryEffectRendererGuiHandler.java in JEI

--- a/src/main/java/codechicken/nei/NEIPotionGuiHandler.java
+++ b/src/main/java/codechicken/nei/NEIPotionGuiHandler.java
@@ -1,0 +1,51 @@
+package codechicken.nei;
+
+import codechicken.lib.vec.Rectangle4i;
+import codechicken.nei.api.INEIGuiAdapter;
+import com.google.common.collect.Ordering;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.client.renderer.InventoryEffectRenderer;
+import net.minecraft.potion.Potion;
+import net.minecraft.potion.PotionEffect;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Inspired by InventoryEffectRendererGuiHandler.java in JEI
+ */
+public class NEIPotionGuiHandler extends INEIGuiAdapter {
+    @Override
+    public boolean hideItemPanelSlot(GuiContainer guiContainer, int slotX, int slotY, int slotW, int slotH) {
+        if(guiContainer instanceof InventoryEffectRenderer) {
+            int x = guiContainer.guiLeft - 124;
+            int y = guiContainer.guiTop;
+            Minecraft minecraft = guiContainer.mc;
+            if (minecraft == null) {
+                return false;
+            }
+            EntityPlayerSP player = minecraft.thePlayer;
+            if (player == null) {
+                return false;
+            }
+            Collection<PotionEffect> activePotionEffects = player.getActivePotionEffects();
+            if (activePotionEffects.isEmpty()) {
+                return false;
+            }
+            int height = 33;
+            if (activePotionEffects.size() > 5) {
+                height = 132 / (activePotionEffects.size() - 1);
+            }
+            Rectangle4i slotRect = new Rectangle4i(slotX, slotY, slotW, slotH);
+            for (PotionEffect potioneffect : activePotionEffects) {
+                Rectangle4i box = new Rectangle4i(x, y, 140, 32);
+                if(box.intersects(slotRect))
+                    return true;
+                y += height;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/codechicken/nei/api/GuiInfo.java
+++ b/src/main/java/codechicken/nei/api/GuiInfo.java
@@ -4,6 +4,7 @@ import codechicken.lib.vec.Rectangle4i;
 import codechicken.nei.NEIChestGuiHandler;
 import codechicken.nei.NEICreativeGuiHandler;
 import codechicken.nei.NEIDummySlotHandler;
+import codechicken.nei.NEIPotionGuiHandler;
 import codechicken.nei.recipe.GuiRecipeCatalyst;
 import codechicken.nei.recipe.SearchInputDropHandler;
 import codechicken.nei.recipe.FillFluidContainerHandler;
@@ -33,6 +34,7 @@ public class GuiInfo {
         API.registerNEIGuiHandler(new SearchInputDropHandler());
         API.registerNEIGuiHandler(new FillFluidContainerHandler());
         API.registerNEIGuiHandler(new CheatItemHandler());
+        API.registerNEIGuiHandler(new NEIPotionGuiHandler());
         customSlotGuis.add(GuiContainerCreative.class);
     }
 

--- a/src/main/resources/assets/nei/lang/en_US.lang
+++ b/src/main/resources/assets/nei/lang/en_US.lang
@@ -179,6 +179,9 @@ nei.options.inventory.disableMouseScrollTransfer.false=False
 nei.options.inventory.invertMouseScrollTransfer=Invert Mouse Wheel Transfer Direction
 nei.options.inventory.invertMouseScrollTransfer.true=True
 nei.options.inventory.invertMouseScrollTransfer.false=False
+nei.options.inventory.cacheItemRendering=Cache Item Rendering
+nei.options.inventory.cacheItemRendering.true=True
+nei.options.inventory.cacheItemRendering.false=False
 
 nei.options.command=Commands
 nei.options.command.creative=Gamemode


### PR DESCRIPTION
This PR adds an optional feature that will cache the item grid rendering in a buffer instead of repeatedly rendering the items on every frame. The advantage is that NEI should no longer have any noticeable FPS impact on the rest of the GUI. The tradeoff is that animated items will now be static. This is why the option is disabled by default.

This implementation is based on https://github.com/CleanroomMC/HadEnoughItems/commit/c3e63362b4bdd490f5111d224f96f01f6f547452, but with appropiate changes for 1.7.10.

One known bug exists that I would appreciate help solving before marking this as ready-for-review: when the [glint rendering fix](https://github.com/jss2a98aj/BugTorch/blob/master/src/main/java/jss/bugtorch/mixins/minecraft/client/renderer/entity/MixinItemRenderer.java) in BugTorch is enabled, items with a glint on them no longer render at all. ~~The `glDepthMask` call I added in `draw` seemed to help with this for enchanted bottles, but they are still missing a glint and enchanted books are completely invisible.~~ `glDepthMask` breaks chest rendering so it's not the solution.