### PR TITLE
Make sure to use utf-8 for bookmark reading as well as writing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1650343995
+//version: 1652851397
 /*
 DO NOT CHANGE THIS FILE!
 
@@ -44,13 +44,14 @@ plugins {
     id 'eclipse'
     id 'scala'
     id 'maven-publish'
-    id 'org.jetbrains.kotlin.jvm'        version '1.5.30' apply false
-    id 'org.jetbrains.kotlin.kapt'       version '1.5.30' apply false
+    id 'org.jetbrains.kotlin.jvm'        version '1.5.30'       apply false
+    id 'org.jetbrains.kotlin.kapt'       version '1.5.30'       apply false
+    id 'com.google.devtools.ksp'         version '1.5.30-1.0.0' apply false
     id 'org.ajoberstar.grgit'            version '4.1.1'
     id 'com.github.johnrengelman.shadow' version '4.0.4'
-    id 'com.palantir.git-version'        version '0.13.0' apply false
+    id 'com.palantir.git-version'        version '0.13.0'       apply false
     id 'de.undercouch.download'          version '5.0.1'
-    id 'com.github.gmazzo.buildconfig'   version '3.0.3'  apply false
+    id 'com.github.gmazzo.buildconfig'   version '3.0.3'        apply false
 }
 
 if (project.file('.git/HEAD').isFile()) {

--- a/src/main/java/codechicken/nei/BookmarkPanel.java
+++ b/src/main/java/codechicken/nei/BookmarkPanel.java
@@ -32,6 +32,7 @@ import java.io.OutputStream;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -547,7 +548,7 @@ public class BookmarkPanel extends PanelWidget
         }
 
         try (FileOutputStream output = new FileOutputStream(bookmarkFile)) {
-            IOUtils.writeLines(strings, "\n", output, "UTF-8");
+            IOUtils.writeLines(strings, "\n", output, StandardCharsets.UTF_8);
         } catch (IOException e) {
             NEIClientConfig.logger.error("Filed to save bookmarks list to file {}", bookmarkFile, e);
         }
@@ -568,9 +569,9 @@ public class BookmarkPanel extends PanelWidget
         }
 
         List<String> itemStrings;
-        try (FileReader reader = new FileReader(bookmarkFile)) {
+        try (FileInputStream reader = new FileInputStream(bookmarkFile)) {
             NEIClientConfig.logger.info("Loading bookmarks from file {}", bookmarkFile);
-            itemStrings = IOUtils.readLines(reader);
+            itemStrings = IOUtils.readLines(reader, StandardCharsets.UTF_8);
         } catch (IOException e) {
             NEIClientConfig.logger.error("Failed to load bookmarks from file {}", bookmarkFile, e);
             return;


### PR DESCRIPTION
The previous code could cause corruption if the default system encoding wasn't utf-8 - writes were explicitly utf-8, while reads used platform default. With the fix both are utf-8. I think this might have been the root cause of the bookmarks.ini corruption bug a couple of people on discord had trouble with.