### PR TITLE
Use a proper key implementation for the search cache

### DIFF
--- a/src/main/java/codechicken/nei/api/ItemInfo.java
+++ b/src/main/java/codechicken/nei/api/ItemInfo.java
@@ -162,14 +162,19 @@ public class ItemInfo
 
     private static void populateSearchMap() {
         /* Create a snapshot of the current keys in the cache */
-        HashSet<ItemStackKey> oldItems = new HashSet<>(itemSearchNames.keySet());
+        HashSet<ItemStackKey> oldItems;
+        synchronized (itemSearchNames) {
+             oldItems = new HashSet<>(itemSearchNames.keySet());
+        }
         for(ItemStack stack : ItemList.items) {
             /* Populate each entry and remove it from the snapshot */
             getSearchName(stack);
             oldItems.remove(new ItemStackKey(stack));
         }
-        /* Remove any remaining items that weren't in use */
-        itemSearchNames.keySet().removeAll(oldItems);
+        synchronized (itemSearchNames) {
+            /* Remove any remaining items that weren't in use */
+            itemSearchNames.keySet().removeAll(oldItems);
+        }
     }
 
     private static void addHiddenItemFilter() {
@@ -557,8 +562,10 @@ public class ItemInfo
     }
 
     public static String getSearchName(ItemStack stack) {
-        return itemSearchNames.computeIfAbsent(new ItemStackKey(stack), key ->
-                EnumChatFormatting.getTextWithoutFormattingCodes(GuiContainerManager.concatenatedDisplayName(key.stack, true).toLowerCase())
-        );
+        synchronized (itemSearchNames) {
+            return itemSearchNames.computeIfAbsent(new ItemStackKey(stack), key ->
+                    EnumChatFormatting.getTextWithoutFormattingCodes(GuiContainerManager.concatenatedDisplayName(key.stack, true).toLowerCase())
+            );
+        }
     }
 }


### PR DESCRIPTION
**Rationale**

I play a fairly large private modpack that includes GT6 and some other mods. As I mentioned in #251, I found that searches take a very long time compared to JEI. After performing some profiling, I discovered that the main bottleneck was in `getSearchName`, due to the fact that a lot of mods implement complex logic when retrieving a tooltip. However, there was already a caching implementation that appeared to be designed to address this issue. The old approach, however, suffered from two problems.

1. It turns out that `ItemStack` does not implement `hashCode` and `equals`. This meant that attempting to retrieve a cached value from `itemSearchMap` using a different instance of the same item stack would not hit the cache.
2. The cache was cleared every time items are reloaded, however, this does not appear to be necessary.

**Changes**

* A new class, `ItemStackKey`, has been introduced that the `itemSearchNames` map makes use of. This class wraps an `ItemStack` and hashes it using its damage, item ID, and any NBT compounds. Usage of this class allows the hash map to still work  properlyeven if you close and reopen your inventory.
* `itemSearchNames` is now populated for every item in `ItemList.items` whenever that list is reloaded. It does take several more seconds for NEI to load when the world is first opened, but after that search times are instantaneous. I did not see any significant increase in memory usage when looking at F3.

I would once again appreciate your feedback in case there's an NEI implementation detail I did not consider.