### PR TITLE
Focus the previous recipe if it's still visible when loading usage re…

### DIFF
--- a/src/main/java/codechicken/nei/recipe/FireworkRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/FireworkRecipeHandler.java
@@ -150,7 +150,7 @@ public class FireworkRecipeHandler extends ShapelessRecipeHandler {
     }
 
     @Override
-    public List<String> handleTooltip(GuiRecipe gui, List<String> currenttip, int recipe) {
+    public List<String> handleTooltip(GuiRecipe<?> gui, List<String> currenttip, int recipe) {
         currenttip = super.handleTooltip(gui, currenttip, recipe);
         Point mousepos = GuiDraw.getMousePosition();
         Point relMouse = new Point(mousepos.x - gui.guiLeft, mousepos.y - gui.guiTop);

--- a/src/main/java/codechicken/nei/recipe/GuiCraftingRecipe.java
+++ b/src/main/java/codechicken/nei/recipe/GuiCraftingRecipe.java
@@ -10,7 +10,10 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.item.ItemStack;
 
-public class GuiCraftingRecipe extends GuiRecipe {
+public class GuiCraftingRecipe extends GuiRecipe<ICraftingHandler> {
+    public static ArrayList<ICraftingHandler> craftinghandlers = new ArrayList<>();
+    public static ArrayList<ICraftingHandler> serialCraftingHandlers = new ArrayList<>();
+
     public static boolean openRecipeGui(String outputId, Object... results) {
         return openRecipeGui(outputId, false, results);
     }
@@ -50,8 +53,8 @@ public class GuiCraftingRecipe extends GuiRecipe {
     protected static BookmarkRecipeId getRecipeId(GuiScreen gui, ItemStack stackover) {
 
         if (gui instanceof GuiRecipe) {
-            final List<PositionedStack> ingredients = ((GuiRecipe) gui).getFocusedRecipeIngredients();
-            final String handlerName = ((GuiRecipe) gui).getHandlerName();
+            final List<PositionedStack> ingredients = ((GuiRecipe<?>) gui).getFocusedRecipeIngredients();
+            final String handlerName = ((GuiRecipe<?>) gui).getHandlerName();
 
             if (ingredients != null && !ingredients.isEmpty()) {
                 return new BookmarkRecipeId(handlerName, ingredients);
@@ -77,12 +80,8 @@ public class GuiCraftingRecipe extends GuiRecipe {
         else craftinghandlers.add(handler);
     }
 
-    public ArrayList<? extends IRecipeHandler> getCurrentRecipeHandlers() {
+    @Override
+    public ArrayList<ICraftingHandler> getCurrentRecipeHandlers() {
         return currenthandlers;
     }
-
-    public ArrayList<ICraftingHandler> currenthandlers;
-
-    public static ArrayList<ICraftingHandler> craftinghandlers = new ArrayList<>();
-    public static ArrayList<ICraftingHandler> serialCraftingHandlers = new ArrayList<>();
 }

--- a/src/main/java/codechicken/nei/recipe/GuiCraftingRecipe.java
+++ b/src/main/java/codechicken/nei/recipe/GuiCraftingRecipe.java
@@ -24,12 +24,13 @@ public class GuiCraftingRecipe extends GuiRecipe {
         Minecraft mc = NEIClientUtils.mc();
 
         BookmarkRecipeId recipeId =
-                "item".equals(outputId) ? getRecipeId(mc.currentScreen, (ItemStack) results[0]) : null;
+                "item".equals(outputId) ? getRecipeId(mc.currentScreen, (ItemStack) results[0]) : getCurrentRecipe();
+
         GuiCraftingRecipe gui = new GuiCraftingRecipe(handlers, recipeId);
 
         mc.displayGuiScreen(gui);
 
-        if (NEIClientConfig.saveCurrentRecipeInBookmarksEnabled())
+        if (NEIClientConfig.saveCurrentRecipeInBookmarksEnabled() || recipeId != null)
             if (!NEIClientUtils.shiftKey() || overlay) {
                 gui.openTargetRecipe(gui.recipeId);
             }

--- a/src/main/java/codechicken/nei/recipe/GuiCraftingRecipe.java
+++ b/src/main/java/codechicken/nei/recipe/GuiCraftingRecipe.java
@@ -26,24 +26,21 @@ public class GuiCraftingRecipe extends GuiRecipe<ICraftingHandler> {
 
         Minecraft mc = NEIClientUtils.mc();
 
-        BookmarkRecipeId recipeId =
-                "item".equals(outputId) ? getRecipeId(mc.currentScreen, (ItemStack) results[0]) : getCurrentRecipe();
+        BookmarkRecipeId recipeId = (NEIClientConfig.saveCurrentRecipeInBookmarksEnabled() && "item".equals(outputId))
+                ? getRecipeId(mc.currentScreen, (ItemStack) results[0])
+                : getCurrentRecipe();
+
+        if (overlay && recipeId == null) return false;
 
         GuiCraftingRecipe gui = new GuiCraftingRecipe(handlers, recipeId);
 
-        GuiScreen prevScreen = mc.currentScreen;
         mc.displayGuiScreen(gui);
 
-        if (NEIClientConfig.saveCurrentRecipeInBookmarksEnabled() || recipeId != null)
-            if (!NEIClientUtils.shiftKey() || overlay) {
-                gui.openTargetRecipe(gui.recipeId);
-            }
+        if (recipeId != null && (!NEIClientUtils.shiftKey() || overlay)) {
+            gui.openTargetRecipe(gui.recipeId);
+        }
 
         if (overlay) {
-            if (!NEIClientConfig.saveCurrentRecipeInBookmarksEnabled() || gui.recipeId == null) {
-                mc.displayGuiScreen(prevScreen);
-                return false;
-            }
             gui.overlayRecipe(gui.recipeId.position);
         }
 

--- a/src/main/java/codechicken/nei/recipe/GuiCraftingRecipe.java
+++ b/src/main/java/codechicken/nei/recipe/GuiCraftingRecipe.java
@@ -28,6 +28,7 @@ public class GuiCraftingRecipe extends GuiRecipe {
 
         GuiCraftingRecipe gui = new GuiCraftingRecipe(handlers, recipeId);
 
+        GuiScreen prevScreen = mc.currentScreen;
         mc.displayGuiScreen(gui);
 
         if (NEIClientConfig.saveCurrentRecipeInBookmarksEnabled() || recipeId != null)
@@ -37,7 +38,7 @@ public class GuiCraftingRecipe extends GuiRecipe {
 
         if (overlay) {
             if (!NEIClientConfig.saveCurrentRecipeInBookmarksEnabled() || gui.recipeId == null) {
-                mc.displayGuiScreen(mc.currentScreen);
+                mc.displayGuiScreen(prevScreen);
                 return false;
             }
             gui.overlayRecipe(gui.recipeId.position);

--- a/src/main/java/codechicken/nei/recipe/GuiCraftingRecipe.java
+++ b/src/main/java/codechicken/nei/recipe/GuiCraftingRecipe.java
@@ -18,7 +18,7 @@ public class GuiCraftingRecipe extends GuiRecipe {
     public static boolean openRecipeGui(String outputId, Boolean overlay, Object... results) {
         RecipeHandlerQuery<ICraftingHandler> recipeQuery = new RecipeHandlerQuery<>(
                 h -> h.getRecipeHandler(outputId, results), craftinghandlers, serialCraftingHandlers);
-        ArrayList<ICraftingHandler> handlers = recipeQuery.run("recipe.concurrent.crafting");
+        ArrayList<ICraftingHandler> handlers = recipeQuery.runWithProfiling("recipe.concurrent.crafting");
         if (handlers.isEmpty()) return false;
 
         Minecraft mc = NEIClientUtils.mc();

--- a/src/main/java/codechicken/nei/recipe/GuiRecipe.java
+++ b/src/main/java/codechicken/nei/recipe/GuiRecipe.java
@@ -39,7 +39,7 @@ import net.minecraft.item.ItemStack;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.opengl.GL11;
 
-public abstract class GuiRecipe extends GuiContainer
+public abstract class GuiRecipe<H extends IRecipeHandler> extends GuiContainer
         implements IGuiContainerOverlay,
                 IGuiClientSide,
                 IGuiHandleMouseWheel,
@@ -67,7 +67,7 @@ public abstract class GuiRecipe extends GuiContainer
     final DrawableResource bgBottom =
             new DrawableBuilder("nei:textures/gui/recipebg.png", 0, BG_BOTTOM_Y, 176, BG_BOTTOM_HEIGHT).build();
 
-    public ArrayList<? extends IRecipeHandler> currenthandlers = new ArrayList<>();
+    public ArrayList<H> currenthandlers = new ArrayList<>();
 
     public int page;
     public int recipetype;
@@ -87,7 +87,7 @@ public abstract class GuiRecipe extends GuiContainer
     private final Rectangle area = new Rectangle();
     private final GuiRecipeTabs recipeTabs;
     private final GuiRecipeCatalyst guiRecipeCatalyst;
-    private IRecipeHandler handler;
+    private H handler;
     private HandlerInfo handlerInfo;
 
     private int yShift = 0;
@@ -237,7 +237,7 @@ public abstract class GuiRecipe extends GuiContainer
             if (recipeId.handlerName != null) {
 
                 for (int j = 0; j < currenthandlers.size(); j++) {
-                    IRecipeHandler localHandler = currenthandlers.get(j);
+                    H localHandler = currenthandlers.get(j);
                     HandlerInfo localHandlerInfo = GuiRecipeTab.getHandlerInfo(localHandler);
 
                     if (localHandlerInfo.getHandlerName().equals(recipeId.handlerName)) {
@@ -294,7 +294,7 @@ public abstract class GuiRecipe extends GuiContainer
         return handlerInfo.getHandlerName();
     }
 
-    public IRecipeHandler getHandler() {
+    public H getHandler() {
         return handler;
     }
 
@@ -687,7 +687,7 @@ public abstract class GuiRecipe extends GuiContainer
         return new Point(5, 32 + yShift + ((recipe % getRecipesPerPage()) * handlerInfo.getHeight()));
     }
 
-    public abstract ArrayList<? extends IRecipeHandler> getCurrentRecipeHandlers();
+    public abstract ArrayList<H> getCurrentRecipeHandlers();
 
     @Override
     public VisiblityData modifyVisiblity(GuiContainer gui, VisiblityData currentVisibility) {
@@ -718,7 +718,7 @@ public abstract class GuiRecipe extends GuiContainer
     static BookmarkRecipeId getCurrentRecipe() {
         Minecraft mc = NEIClientUtils.mc();
         if (mc.currentScreen instanceof GuiRecipe) {
-            GuiRecipe gui = (GuiRecipe) mc.currentScreen;
+            GuiRecipe<?> gui = (GuiRecipe<?>) mc.currentScreen;
             return new BookmarkRecipeId(
                     gui.handlerInfo.getHandlerName(),
                     gui.getHandler().getIngredientStacks(gui.page * gui.getRecipesPerPage()));

--- a/src/main/java/codechicken/nei/recipe/GuiRecipe.java
+++ b/src/main/java/codechicken/nei/recipe/GuiRecipe.java
@@ -81,7 +81,7 @@ public abstract class GuiRecipe<H extends IRecipeHandler> extends GuiContainer
     private GuiButton nexttype;
     private GuiButton prevtype;
 
-    private int OVERLAY_BUTTON_ID_START = 4;
+    private final int OVERLAY_BUTTON_ID_START = 4;
     private GuiButton[] overlayButtons;
 
     private final Rectangle area = new Rectangle();

--- a/src/main/java/codechicken/nei/recipe/GuiRecipe.java
+++ b/src/main/java/codechicken/nei/recipe/GuiRecipe.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.inventory.GuiContainer;
@@ -712,5 +713,15 @@ public abstract class GuiRecipe extends GuiContainer
     public boolean hideItemPanelSlot(GuiContainer gui, int x, int y, int w, int h) {
         // Because some of the handlers *cough avaritia* are oversized
         return area.intersects(x, y, w, h);
+    }
+
+    static BookmarkRecipeId getCurrentRecipe() {
+        Minecraft mc = NEIClientUtils.mc();
+        if (mc.currentScreen instanceof GuiRecipe) {
+            GuiRecipe gui = (GuiRecipe) mc.currentScreen;
+            return  new BookmarkRecipeId(gui.handlerInfo.getHandlerName(),
+                    gui.getHandler().getIngredientStacks(gui.page * gui.getRecipesPerPage()));
+        }
+        return null;
     }
 }

--- a/src/main/java/codechicken/nei/recipe/GuiRecipe.java
+++ b/src/main/java/codechicken/nei/recipe/GuiRecipe.java
@@ -1,7 +1,9 @@
 package codechicken.nei.recipe;
 
+import codechicken.core.TaskProfiler;
 import codechicken.lib.gui.GuiDraw;
 import codechicken.nei.GuiNEIButton;
+import codechicken.nei.ItemList;
 import codechicken.nei.LayoutManager;
 import codechicken.nei.NEIClientConfig;
 import codechicken.nei.NEIClientUtils;
@@ -25,6 +27,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -34,8 +38,12 @@ import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.IChatComponent;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.opengl.GL11;
 
@@ -719,9 +727,65 @@ public abstract class GuiRecipe extends GuiContainer
         Minecraft mc = NEIClientUtils.mc();
         if (mc.currentScreen instanceof GuiRecipe) {
             GuiRecipe gui = (GuiRecipe) mc.currentScreen;
-            return  new BookmarkRecipeId(gui.handlerInfo.getHandlerName(),
+            return new BookmarkRecipeId(
+                    gui.handlerInfo.getHandlerName(),
                     gui.getHandler().getIngredientStacks(gui.page * gui.getRecipesPerPage()));
         }
         return null;
+    }
+
+    static class RecipeHandlerQuery<T extends IRecipeHandler> {
+        private final Function<T, T> recipeHandlerFunction;
+        private final List<T> recipeHandlers;
+        private final List<T> serialRecipeHandlers;
+
+        RecipeHandlerQuery(Function<T, T> recipeHandlerFunction, List<T> recipeHandlers, List<T> serialRecipeHandlers) {
+            this.recipeHandlerFunction = recipeHandlerFunction;
+            this.recipeHandlers = recipeHandlers;
+            this.serialRecipeHandlers = serialRecipeHandlers;
+        }
+
+        ArrayList<T> run(String profilerSection) {
+            TaskProfiler profiler = ProfilerRecipeHandler.getProfiler();
+            profiler.start(profilerSection);
+            try {
+                return getRecipeHandlersParallel();
+            } catch (InterruptedException | ExecutionException e) {
+                displayRecipeLookupError(e);
+                return new ArrayList<>(0);
+            } finally {
+                profiler.end();
+            }
+        }
+
+        private ArrayList<T> getRecipeHandlersParallel() throws InterruptedException, ExecutionException {
+            // Pre-find the fuels so we're not fighting over it
+            FuelRecipeHandler.findFuelsOnceParallel();
+
+            ArrayList<T> handlers = serialRecipeHandlers.stream()
+                    .map(recipeHandlerFunction)
+                    .filter(h -> h.numRecipes() > 0)
+                    .collect(Collectors.toCollection(ArrayList::new));
+
+            handlers.addAll(ItemList.forkJoinPool
+                    .submit(() -> recipeHandlers.parallelStream()
+                            .map(recipeHandlerFunction)
+                            .filter(h -> h.numRecipes() > 0)
+                            .collect(Collectors.toCollection(ArrayList::new)))
+                    .get());
+
+            handlers.sort(NEIClientConfig.HANDLER_COMPARATOR);
+            return handlers;
+        }
+
+        private static void displayRecipeLookupError(Exception e) {
+            e.printStackTrace();
+            EntityPlayer player = Minecraft.getMinecraft().thePlayer;
+            if (player != null) {
+                IChatComponent chat = new ChatComponentTranslation("nei.chat.recipe.error");
+                chat.getChatStyle().setColor(EnumChatFormatting.RED);
+                player.addChatComponentMessage(chat);
+            }
+        }
     }
 }

--- a/src/main/java/codechicken/nei/recipe/GuiRecipeCatalyst.java
+++ b/src/main/java/codechicken/nei/recipe/GuiRecipeCatalyst.java
@@ -9,7 +9,7 @@ import net.minecraft.util.ResourceLocation;
 import org.lwjgl.util.Rectangle;
 
 public class GuiRecipeCatalyst extends INEIGuiAdapter {
-    private GuiRecipe guiRecipe;
+    private GuiRecipe<?> guiRecipe;
     public static final int ingredientSize = 16;
     public static final int ingredientBorder = 1;
     public static final int tabBorder = 5;
@@ -18,7 +18,7 @@ public class GuiRecipeCatalyst extends INEIGuiAdapter {
     private static final Rectangle catalystRect = new Rectangle();
     private static final Rectangle targetRect = new Rectangle();
 
-    public GuiRecipeCatalyst(GuiRecipe guiRecipe) {
+    public GuiRecipeCatalyst(GuiRecipe<?> guiRecipe) {
         this.guiRecipe = guiRecipe;
     }
 
@@ -49,7 +49,7 @@ public class GuiRecipeCatalyst extends INEIGuiAdapter {
     @Override
     public boolean hideItemPanelSlot(GuiContainer gui, int x, int y, int w, int h) {
         if (!(gui instanceof GuiRecipe)) return false;
-        guiRecipe = (GuiRecipe) gui;
+        guiRecipe = (GuiRecipe<?>) gui;
         int catalystsSize =
                 RecipeCatalysts.getRecipeCatalysts(guiRecipe.getHandler()).size();
         if (catalystsSize == 0) return false;

--- a/src/main/java/codechicken/nei/recipe/GuiRecipeTab.java
+++ b/src/main/java/codechicken/nei/recipe/GuiRecipeTab.java
@@ -35,7 +35,7 @@ public abstract class GuiRecipeTab extends Widget {
     public static HashMap<String, HandlerInfo> handlerAdderFromIMC = new HashMap<>();
     public static Set<String> handlerRemoverFromIMC = new HashSet<>();
 
-    private final GuiRecipe guiRecipe;
+    private final GuiRecipe<?> guiRecipe;
     private final IRecipeHandler handler;
     private final String handlerName;
     private final String handlerID;
@@ -54,7 +54,7 @@ public abstract class GuiRecipeTab extends Widget {
 
     protected abstract int getForegroundIconY();
 
-    public GuiRecipeTab(GuiRecipe guiRecipe, IRecipeHandler handler, int x, int y) {
+    public GuiRecipeTab(GuiRecipe<?> guiRecipe, IRecipeHandler handler, int x, int y) {
         super();
         this.x = x;
         this.y = y;

--- a/src/main/java/codechicken/nei/recipe/GuiRecipeTabCreative.java
+++ b/src/main/java/codechicken/nei/recipe/GuiRecipeTabCreative.java
@@ -11,7 +11,7 @@ public class GuiRecipeTabCreative extends GuiRecipeTab {
     private static final DrawableResource unselectedTabImage =
             new DrawableBuilder("minecraft:textures/gui/container/creative_inventory/tabs.png", 28, 0, 28, 30).build();
 
-    public GuiRecipeTabCreative(GuiRecipe guiRecipe, IRecipeHandler handler, int x, int y) {
+    public GuiRecipeTabCreative(GuiRecipe<?> guiRecipe, IRecipeHandler handler, int x, int y) {
         super(guiRecipe, handler, x, y);
     }
 

--- a/src/main/java/codechicken/nei/recipe/GuiRecipeTabJEI.java
+++ b/src/main/java/codechicken/nei/recipe/GuiRecipeTabJEI.java
@@ -11,7 +11,7 @@ public class GuiRecipeTabJEI extends GuiRecipeTab {
     private static final DrawableResource unselectedTabImage =
             new DrawableBuilder("nei:textures/nei_tabbed_sprites.png", 24, 16, 24, 24).build();
 
-    public GuiRecipeTabJEI(GuiRecipe guiRecipe, IRecipeHandler handler, int x, int y) {
+    public GuiRecipeTabJEI(GuiRecipe<?> guiRecipe, IRecipeHandler handler, int x, int y) {
         super(guiRecipe, handler, x, y);
     }
 

--- a/src/main/java/codechicken/nei/recipe/GuiRecipeTabs.java
+++ b/src/main/java/codechicken/nei/recipe/GuiRecipeTabs.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class GuiRecipeTabs {
-    private final GuiRecipe guiRecipe;
+    private final GuiRecipe<?> guiRecipe;
     private final List<GuiRecipeTab> tabs = new ArrayList<>();
     private final List<Button> buttons = new ArrayList<>();
 
@@ -22,7 +22,7 @@ public class GuiRecipeTabs {
     private int tabWidth;
     private int tabHeight;
 
-    public GuiRecipeTabs(GuiRecipe guiRecipe) {
+    public GuiRecipeTabs(GuiRecipe<?> guiRecipe) {
         this.guiRecipe = guiRecipe;
     }
 

--- a/src/main/java/codechicken/nei/recipe/GuiRecipeTabs.java
+++ b/src/main/java/codechicken/nei/recipe/GuiRecipeTabs.java
@@ -13,7 +13,6 @@ public class GuiRecipeTabs {
     private final List<Button> buttons = new ArrayList<>();
 
     private final Rectangle area = new Rectangle();
-    private boolean creative_tab_style;
 
     private int pageCount = 1;
     private int pageNumber = 0;
@@ -27,8 +26,7 @@ public class GuiRecipeTabs {
     }
 
     public void initLayout() {
-        creative_tab_style = NEIClientConfig.useCreativeTabStyle();
-        if (creative_tab_style) {
+        if (NEIClientConfig.useCreativeTabStyle()) {
             tabWidth = GuiRecipeTabCreative.TAB_WIDTH;
             tabHeight = GuiRecipeTabCreative.TAB_HEIGHT;
         } else {

--- a/src/main/java/codechicken/nei/recipe/GuiUsageRecipe.java
+++ b/src/main/java/codechicken/nei/recipe/GuiUsageRecipe.java
@@ -1,81 +1,32 @@
 package codechicken.nei.recipe;
 
-import codechicken.core.TaskProfiler;
-import codechicken.nei.ItemList;
 import codechicken.nei.NEIClientConfig;
 import codechicken.nei.NEIClientUtils;
 import java.util.ArrayList;
-import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.inventory.GuiContainer;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.util.ChatComponentTranslation;
-import net.minecraft.util.EnumChatFormatting;
-import net.minecraft.util.IChatComponent;
 
 public class GuiUsageRecipe extends GuiRecipe {
     public static boolean openRecipeGui(String inputId, Object... ingredients) {
-        Minecraft mc = NEIClientUtils.mc();
-        GuiContainer prevscreen = mc.currentScreen instanceof GuiContainer ? (GuiContainer) mc.currentScreen : null;
-
-        ArrayList<IUsageHandler> handlers;
-        TaskProfiler profiler = ProfilerRecipeHandler.getProfiler();
-
-        // Pre-find the fuels so we're not fighting over it
-        FuelRecipeHandler.findFuelsOnceParallel();
-
-        profiler.start("recipe.concurrent.usage");
-        try {
-            handlers = serialUsageHandlers.stream()
-                    .map(h -> getUsageOrCatalystHandler(h, inputId, ingredients))
-                    .filter(h -> h.numRecipes() > 0)
-                    .collect(Collectors.toCollection(ArrayList::new));
-
-            handlers.addAll(ItemList.forkJoinPool
-                    .submit(() -> usagehandlers.parallelStream()
-                            .map(h -> getUsageOrCatalystHandler(h, inputId, ingredients))
-                            .filter(h -> h.numRecipes() > 0)
-                            .collect(Collectors.toCollection(ArrayList::new)))
-                    .get());
-        } catch (InterruptedException | ExecutionException e) {
-            e.printStackTrace();
-            EntityPlayer player = Minecraft.getMinecraft().thePlayer;
-            if (player != null) {
-                IChatComponent chat = new ChatComponentTranslation("nei.chat.recipe.error");
-                chat.getChatStyle().setColor(EnumChatFormatting.RED);
-                player.addChatComponentMessage(chat);
-            }
-            return false;
-        } finally {
-            profiler.end();
-        }
-
+        RecipeHandlerQuery<IUsageHandler> recipeQuery = new RecipeHandlerQuery<>(
+                h -> getUsageOrCatalystHandler(h, inputId, ingredients), usagehandlers, serialUsageHandlers);
+        ArrayList<IUsageHandler> handlers = recipeQuery.run("recipe.concurrent.usage");
         if (handlers.isEmpty()) return false;
 
-        handlers.sort(NEIClientConfig.HANDLER_COMPARATOR);
-
         BookmarkRecipeId recipeId = getCurrentRecipe();
+        GuiUsageRecipe gui = new GuiUsageRecipe(handlers, recipeId);
 
-        GuiUsageRecipe gui = new GuiUsageRecipe(prevscreen, handlers, recipeId);
-
-        mc.displayGuiScreen(gui);
+        NEIClientUtils.mc().displayGuiScreen(gui);
 
         if (!NEIClientUtils.shiftKey()) {
-            gui.openTargetRecipe(recipeId);
+            gui.openTargetRecipe(gui.recipeId);
         }
 
         return true;
     }
 
-    private GuiUsageRecipe(GuiContainer prevgui, ArrayList<IUsageHandler> handlers, BookmarkRecipeId recipeId) {
-        this(prevgui, handlers);
+    private GuiUsageRecipe(ArrayList<IUsageHandler> handlers, BookmarkRecipeId recipeId) {
+        super(NEIClientUtils.mc().currentScreen);
+        this.currenthandlers = handlers;
         this.recipeId = recipeId;
-    }
-
-    private GuiUsageRecipe(GuiContainer prevgui, ArrayList<IUsageHandler> handlers) {
-        super(prevgui);
-        currenthandlers = handlers;
     }
 
     public static void registerUsageHandler(IUsageHandler handler) {

--- a/src/main/java/codechicken/nei/recipe/GuiUsageRecipe.java
+++ b/src/main/java/codechicken/nei/recipe/GuiUsageRecipe.java
@@ -8,7 +8,7 @@ public class GuiUsageRecipe extends GuiRecipe {
     public static boolean openRecipeGui(String inputId, Object... ingredients) {
         RecipeHandlerQuery<IUsageHandler> recipeQuery = new RecipeHandlerQuery<>(
                 h -> getUsageOrCatalystHandler(h, inputId, ingredients), usagehandlers, serialUsageHandlers);
-        ArrayList<IUsageHandler> handlers = recipeQuery.run("recipe.concurrent.usage");
+        ArrayList<IUsageHandler> handlers = recipeQuery.runWithProfiling("recipe.concurrent.usage");
         if (handlers.isEmpty()) return false;
 
         BookmarkRecipeId recipeId = getCurrentRecipe();

--- a/src/main/java/codechicken/nei/recipe/GuiUsageRecipe.java
+++ b/src/main/java/codechicken/nei/recipe/GuiUsageRecipe.java
@@ -55,11 +55,7 @@ public class GuiUsageRecipe extends GuiRecipe {
 
         handlers.sort(NEIClientConfig.HANDLER_COMPARATOR);
 
-        BookmarkRecipeId recipeId = null;
-
-        if (prevscreen instanceof GuiRecipe && ((GuiRecipe) prevscreen).recipeId != null) {
-            recipeId = (((GuiRecipe) prevscreen).recipeId).copy();
-        }
+        BookmarkRecipeId recipeId = getCurrentRecipe();
 
         GuiUsageRecipe gui = new GuiUsageRecipe(prevscreen, handlers, recipeId);
 

--- a/src/main/java/codechicken/nei/recipe/GuiUsageRecipe.java
+++ b/src/main/java/codechicken/nei/recipe/GuiUsageRecipe.java
@@ -4,7 +4,10 @@ import codechicken.nei.NEIClientConfig;
 import codechicken.nei.NEIClientUtils;
 import java.util.ArrayList;
 
-public class GuiUsageRecipe extends GuiRecipe {
+public class GuiUsageRecipe extends GuiRecipe<IUsageHandler> {
+    public static ArrayList<IUsageHandler> usagehandlers = new ArrayList<>();
+    public static ArrayList<IUsageHandler> serialUsageHandlers = new ArrayList<>();
+
     public static boolean openRecipeGui(String inputId, Object... ingredients) {
         RecipeHandlerQuery<IUsageHandler> recipeQuery = new RecipeHandlerQuery<>(
                 h -> getUsageOrCatalystHandler(h, inputId, ingredients), usagehandlers, serialUsageHandlers);
@@ -38,10 +41,6 @@ public class GuiUsageRecipe extends GuiRecipe {
         else usagehandlers.add(handler);
     }
 
-    public ArrayList<? extends IRecipeHandler> getCurrentRecipeHandlers() {
-        return currenthandlers;
-    }
-
     private static IUsageHandler getUsageOrCatalystHandler(
             IUsageHandler handler, String inputId, Object... ingredients) {
         boolean skipCatalyst = NEIClientUtils.controlKey();
@@ -52,8 +51,8 @@ public class GuiUsageRecipe extends GuiRecipe {
         }
     }
 
-    public ArrayList<IUsageHandler> currenthandlers;
-
-    public static ArrayList<IUsageHandler> usagehandlers = new ArrayList<>();
-    public static ArrayList<IUsageHandler> serialUsageHandlers = new ArrayList<>();
+    @Override
+    public ArrayList<IUsageHandler> getCurrentRecipeHandlers() {
+        return currenthandlers;
+    }
 }

--- a/src/main/java/codechicken/nei/recipe/IRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/IRecipeHandler.java
@@ -117,7 +117,7 @@ public interface IRecipeHandler {
      * @param recipe The recipe index being handled
      * @return The modified tooltip. DO NOT return null
      */
-    List<String> handleTooltip(GuiRecipe gui, List<String> currenttip, int recipe);
+    List<String> handleTooltip(GuiRecipe<?> gui, List<String> currenttip, int recipe);
     /**
      *
      * @param gui An instance of the currentscreen
@@ -126,7 +126,7 @@ public interface IRecipeHandler {
      * @param recipe The recipe index being handled
      * @return The modified tooltip. DO NOT return null
      */
-    List<String> handleItemTooltip(GuiRecipe gui, ItemStack stack, List<String> currenttip, int recipe);
+    List<String> handleItemTooltip(GuiRecipe<?> gui, ItemStack stack, List<String> currenttip, int recipe);
 
     /**
      *
@@ -135,7 +135,7 @@ public interface IRecipeHandler {
      * @param keyCode The KeyCode as defined in {@link Keyboard}
      * @return true to terminate further processing of this event.
      */
-    boolean keyTyped(GuiRecipe gui, char keyChar, int keyCode, int recipe);
+    boolean keyTyped(GuiRecipe<?> gui, char keyChar, int keyCode, int recipe);
 
     /**
      *
@@ -143,7 +143,7 @@ public interface IRecipeHandler {
      * @param button The button index being pressed, {0 = Left Click, 1 = Right Click, 2 = Middle Click}
      * @return true to terminate further processing of this event.
      */
-    boolean mouseClicked(GuiRecipe gui, int button, int recipe);
+    boolean mouseClicked(GuiRecipe<?> gui, int button, int recipe);
 
     /**
      * For legacy compatibility reasons, this method has a do-nothing default implementation.
@@ -152,7 +152,7 @@ public interface IRecipeHandler {
      * @param scroll The scroll direction, {> 0 = Up, < 0 = Down}
      * @return true to terminate further processing of this event.
      */
-    default boolean mouseScrolled(GuiRecipe gui, int scroll, int recipe) {
+    default boolean mouseScrolled(GuiRecipe<?> gui, int scroll, int recipe) {
         return false;
     }
 }

--- a/src/main/java/codechicken/nei/recipe/ProfilerRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/ProfilerRecipeHandler.java
@@ -110,22 +110,22 @@ public class ProfilerRecipeHandler implements ICraftingHandler, IUsageHandler {
     }
 
     @Override
-    public List<String> handleTooltip(GuiRecipe gui, List<String> currenttip, int recipe) {
+    public List<String> handleTooltip(GuiRecipe<?> gui, List<String> currenttip, int recipe) {
         return currenttip;
     }
 
     @Override
-    public List<String> handleItemTooltip(GuiRecipe gui, ItemStack stack, List<String> currenttip, int recipe) {
+    public List<String> handleItemTooltip(GuiRecipe<?> gui, ItemStack stack, List<String> currenttip, int recipe) {
         return currenttip;
     }
 
     @Override
-    public boolean keyTyped(GuiRecipe gui, char keyChar, int keyCode, int recipe) {
+    public boolean keyTyped(GuiRecipe<?> gui, char keyChar, int keyCode, int recipe) {
         return false;
     }
 
     @Override
-    public boolean mouseClicked(GuiRecipe gui, int button, int recipe) {
+    public boolean mouseClicked(GuiRecipe<?> gui, int button, int recipe) {
         return false;
     }
 

--- a/src/main/java/codechicken/nei/recipe/RecipeHandlerQuery.java
+++ b/src/main/java/codechicken/nei/recipe/RecipeHandlerQuery.java
@@ -1,0 +1,70 @@
+package codechicken.nei.recipe;
+
+import codechicken.core.TaskProfiler;
+import codechicken.nei.ItemList;
+import codechicken.nei.NEIClientConfig;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.IChatComponent;
+
+class RecipeHandlerQuery<T extends IRecipeHandler> {
+    private final Function<T, T> recipeHandlerFunction;
+    private final List<T> recipeHandlers;
+    private final List<T> serialRecipeHandlers;
+
+    RecipeHandlerQuery(Function<T, T> recipeHandlerFunction, List<T> recipeHandlers, List<T> serialRecipeHandlers) {
+        this.recipeHandlerFunction = recipeHandlerFunction;
+        this.recipeHandlers = recipeHandlers;
+        this.serialRecipeHandlers = serialRecipeHandlers;
+    }
+
+    ArrayList<T> run(String profilerSection) {
+        TaskProfiler profiler = ProfilerRecipeHandler.getProfiler();
+        profiler.start(profilerSection);
+        try {
+            return getRecipeHandlersParallel();
+        } catch (InterruptedException | ExecutionException e) {
+            displayRecipeLookupError(e);
+            return new ArrayList<>(0);
+        } finally {
+            profiler.end();
+        }
+    }
+
+    private ArrayList<T> getRecipeHandlersParallel() throws InterruptedException, ExecutionException {
+        // Pre-find the fuels so we're not fighting over it
+        FuelRecipeHandler.findFuelsOnceParallel();
+
+        ArrayList<T> handlers = serialRecipeHandlers.stream()
+                .map(recipeHandlerFunction)
+                .filter(h -> h.numRecipes() > 0)
+                .collect(Collectors.toCollection(ArrayList::new));
+
+        handlers.addAll(ItemList.forkJoinPool
+                .submit(() -> recipeHandlers.parallelStream()
+                        .map(recipeHandlerFunction)
+                        .filter(h -> h.numRecipes() > 0)
+                        .collect(Collectors.toCollection(ArrayList::new)))
+                .get());
+
+        handlers.sort(NEIClientConfig.HANDLER_COMPARATOR);
+        return handlers;
+    }
+
+    private static void displayRecipeLookupError(Exception e) {
+        e.printStackTrace();
+        EntityPlayer player = Minecraft.getMinecraft().thePlayer;
+        if (player != null) {
+            IChatComponent chat = new ChatComponentTranslation("nei.chat.recipe.error");
+            chat.getChatStyle().setColor(EnumChatFormatting.RED);
+            player.addChatComponentMessage(chat);
+        }
+    }
+}

--- a/src/main/java/codechicken/nei/recipe/RecipeItemInputHandler.java
+++ b/src/main/java/codechicken/nei/recipe/RecipeItemInputHandler.java
@@ -29,8 +29,8 @@ public class RecipeItemInputHandler implements IContainerInputHandler {
             String handlerName = "";
 
             if (gui instanceof GuiRecipe && NEIClientConfig.saveCurrentRecipeInBookmarksEnabled()) {
-                ingredients = ((GuiRecipe) gui).getFocusedRecipeIngredients();
-                handlerName = ((GuiRecipe) gui).getHandlerName();
+                ingredients = ((GuiRecipe<?>) gui).getFocusedRecipeIngredients();
+                handlerName = ((GuiRecipe<?>) gui).getHandlerName();
             }
 
             ItemPanels.bookmarkPanel.addOrRemoveItem(stackover.copy(), handlerName, ingredients);

--- a/src/main/java/codechicken/nei/recipe/ShapedRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/ShapedRecipeHandler.java
@@ -36,11 +36,6 @@ public class ShapedRecipeHandler extends TemplateRecipeHandler {
             this(recipe.recipeWidth, recipe.recipeHeight, recipe.recipeItems, recipe.getRecipeOutput());
         }
 
-        /**
-         * @param width
-         * @param height
-         * @param items  an ItemStack[] or ItemStack[][]
-         */
         public void setIngredients(int width, int height, Object[] items) {
             for (int x = 0; x < width; x++) {
                 for (int y = 0; y < height; y++) {

--- a/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
@@ -172,8 +172,10 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
 
         /**
          * This will perform default cycling of ingredients, mulitItem capable
-         *
-         * @return
+         * @param cycle Current cycle step
+         * @param ingredients List of ItemStacks to cycle
+         * @return The provided list of ingredients, with their permutations cycled to a different permutation, if one
+         *         is available
          */
         public List<PositionedStack> getCycledIngredients(int cycle, List<PositionedStack> ingredients) {
             for (int itemIndex = 0; itemIndex < ingredients.size(); itemIndex++)
@@ -187,11 +189,6 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
             stack.setPermutationToRender(Math.abs(rand.nextInt()) % stack.items.length);
         }
 
-        /**
-         * Set all variable ingredients to this permutation.
-         *
-         * @param ingredient
-         */
         public void setIngredientPermutation(Collection<PositionedStack> ingredients, ItemStack ingredient) {
             for (PositionedStack stack : ingredients) {
                 for (int i = 0; i < stack.items.length; i++) {
@@ -211,8 +208,9 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
         }
 
         /**
-         * @param ingredient
-         * @return true if any of the permutations of any of the ingredients contain this stack
+         * @param ingredients Collection of ItemStacks
+         * @param ingredient ItemStack we're looking for
+         * @return true if any of the permutations of the ingredients contain this ItemStack
          */
         public boolean contains(Collection<PositionedStack> ingredients, ItemStack ingredient) {
             for (PositionedStack stack : ingredients) if (stack.contains(ingredient)) return true;
@@ -230,11 +228,12 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
         }
 
         /**
-         * @param ingred
-         * @return true if any of the permutations of any of the ingredients contain this stack
+         * @param ingredients Collection of ItemStacks
+         * @param ingredient Item we're looking for
+         * @return true if any of the permutations of the ingredients contain this Item
          */
-        public boolean contains(Collection<PositionedStack> ingredients, Item ingred) {
-            for (PositionedStack stack : ingredients) if (stack.contains(ingred)) return true;
+        public boolean contains(Collection<PositionedStack> ingredients, Item ingredient) {
+            for (PositionedStack stack : ingredients) if (stack.contains(ingredient)) return true;
             return false;
         }
     }
@@ -266,7 +265,8 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
     }
 
     public static class RecipeTransferRectHandler implements IContainerInputHandler, IContainerTooltipHandler {
-        private static HashMap<Class<? extends GuiContainer>, HashSet<RecipeTransferRect>> guiMap = new HashMap<>();
+        private static final HashMap<Class<? extends GuiContainer>, HashSet<RecipeTransferRect>> guiMap =
+                new HashMap<>();
 
         public static void registerRectsToGuis(
                 List<Class<? extends GuiContainer>> classes, List<RecipeTransferRect> rects) {

--- a/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
@@ -630,7 +630,7 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
     }
 
     @Override
-    public List<String> handleTooltip(GuiRecipe gui, List<String> currenttip, int recipe) {
+    public List<String> handleTooltip(GuiRecipe<?> gui, List<String> currenttip, int recipe) {
         if (GuiContainerManager.shouldShowTooltip(gui) && currenttip.size() == 0) {
             Point offset = gui.getRecipePosition(recipe);
             currenttip = transferRectTooltip(gui, transferRects, offset.x, offset.y, currenttip);
@@ -639,12 +639,12 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
     }
 
     @Override
-    public List<String> handleItemTooltip(GuiRecipe gui, ItemStack stack, List<String> currenttip, int recipe) {
+    public List<String> handleItemTooltip(GuiRecipe<?> gui, ItemStack stack, List<String> currenttip, int recipe) {
         return currenttip;
     }
 
     @Override
-    public boolean keyTyped(GuiRecipe gui, char keyChar, int keyCode, int recipe) {
+    public boolean keyTyped(GuiRecipe<?> gui, char keyChar, int keyCode, int recipe) {
         if (keyCode == NEIClientConfig.getKeyBinding("gui.recipe")) return transferRect(gui, recipe, false);
         else if (keyCode == NEIClientConfig.getKeyBinding("gui.usage")) return transferRect(gui, recipe, true);
 
@@ -652,7 +652,7 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
     }
 
     @Override
-    public boolean mouseClicked(GuiRecipe gui, int button, int recipe) {
+    public boolean mouseClicked(GuiRecipe<?> gui, int button, int recipe) {
         if (button == 0) return transferRect(gui, recipe, false);
         else if (button == 1) return transferRect(gui, recipe, true);
 
@@ -660,11 +660,11 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
     }
 
     @Override
-    public boolean mouseScrolled(GuiRecipe gui, int scroll, int recipe) {
+    public boolean mouseScrolled(GuiRecipe<?> gui, int scroll, int recipe) {
         return false;
     }
 
-    private boolean transferRect(GuiRecipe gui, int recipe, boolean usage) {
+    private boolean transferRect(GuiRecipe<?> gui, int recipe, boolean usage) {
         Point offset = gui.getRecipePosition(recipe);
         return transferRect(gui, transferRects, offset.x, offset.y, usage);
     }


### PR DESCRIPTION
Focus the previous recipe if it's still visible when loading usage recipes. Lets basic machine catalysts seamlessly update the overclock information.

![sticky-catalysts](https://user-images.githubusercontent.com/5321549/175837857-815ddcd7-38af-4f56-9ecf-50c9e1b0ce54.gif)
