### PR TITLE
Add ClickContext for INEIGuiHandler

### DIFF
--- a/src/main/java/codechicken/nei/PanelWidget.java
+++ b/src/main/java/codechicken/nei/PanelWidget.java
@@ -2,6 +2,7 @@ package codechicken.nei;
 
 import codechicken.lib.vec.Rectangle4i;
 import codechicken.nei.ItemPanel.ItemPanelSlot;
+import codechicken.nei.api.ClickContext;
 import codechicken.nei.api.GuiInfo;
 import codechicken.nei.api.INEIGuiHandler;
 import codechicken.nei.guihook.GuiContainerManager;
@@ -242,27 +243,29 @@ public abstract class PanelWidget extends Widget {
     @Override
     public boolean handleClickExt(int mouseX, int mouseY, int button) {
         if (ItemPanels.itemPanel.draggedStack != null) {
-            return ItemPanels.itemPanel.handleDraggedClick(mouseX, mouseY, button);
+            return ItemPanels.itemPanel.handleDraggedClick(
+                    mouseX, mouseY, button, ClickContext.GHOST_DRAGGED_ITEM_PANEL);
         }
 
         if (ItemPanels.bookmarkPanel.draggedStack != null) {
-            return ItemPanels.bookmarkPanel.handleDraggedClick(mouseX, mouseY, button);
+            return ItemPanels.bookmarkPanel.handleDraggedClick(
+                    mouseX, mouseY, button, ClickContext.GHOST_DRAGGED_BOOKMARK_PANEL);
         }
 
         if (NEIClientUtils.getHeldItem() != null) {
             final ItemStack draggedStack = NEIClientUtils.getHeldItem().copy();
-            return handleGUIContainerClick(draggedStack, mouseX, mouseY, button);
+            return handleGUIContainerClick(draggedStack, mouseX, mouseY, button, ClickContext.REAL_ITEM);
         }
 
         return false;
     }
 
-    protected boolean handleDraggedClick(int mouseX, int mouseY, int button) {
+    protected boolean handleDraggedClick(int mouseX, int mouseY, int button, ClickContext clickContext) {
         if (draggedStack == null) {
             return false;
         }
 
-        if (handleGUIContainerClick(draggedStack, mouseX, mouseY, button)) {
+        if (handleGUIContainerClick(draggedStack, mouseX, mouseY, button, clickContext)) {
 
             if (draggedStack.stackSize == 0) {
                 draggedStack = null;
@@ -282,14 +285,15 @@ public abstract class PanelWidget extends Widget {
         return true;
     }
 
-    protected boolean handleGUIContainerClick(final ItemStack draggedStack, int mouseX, int mouseY, int button) {
+    protected boolean handleGUIContainerClick(
+            final ItemStack draggedStack, int mouseX, int mouseY, int button, ClickContext clickContext) {
         final GuiContainer gui = NEIClientUtils.getGuiContainer();
         boolean handled = false;
 
         try {
             GuiInfo.readLock.lock();
             for (INEIGuiHandler handler : GuiInfo.guiHandlers) {
-                if (handler.handleDragNDrop(gui, mouseX, mouseY, draggedStack, button)) {
+                if (handler.handleDragNDrop(gui, mouseX, mouseY, draggedStack, button, clickContext)) {
                     handled = true;
                     break;
                 }

--- a/src/main/java/codechicken/nei/api/ClickContext.java
+++ b/src/main/java/codechicken/nei/api/ClickContext.java
@@ -1,0 +1,21 @@
+package codechicken.nei.api;
+
+@SuppressWarnings("unused")
+public enum ClickContext {
+    /**
+     * ItemStack is dragged from ItemPanel, and not real item player holds
+     */
+    GHOST_DRAGGED_ITEM_PANEL,
+    /**
+     * ItemStack is dragged from BookmarkPanel, and not real item player holds
+     */
+    GHOST_DRAGGED_BOOKMARK_PANEL,
+    /**
+     * Normal click. ItemStack is actually held by player
+     */
+    REAL_ITEM;
+
+    public boolean isGhostDragged() {
+        return this == GHOST_DRAGGED_ITEM_PANEL || this == GHOST_DRAGGED_BOOKMARK_PANEL;
+    }
+}

--- a/src/main/java/codechicken/nei/api/INEIGuiHandler.java
+++ b/src/main/java/codechicken/nei/api/INEIGuiHandler.java
@@ -8,6 +8,7 @@ import net.minecraft.item.ItemStack;
 /**
  * If this is implemented on a gui, it will be automatically registered
  */
+@SuppressWarnings("unused")
 public interface INEIGuiHandler {
     public VisiblityData modifyVisiblity(GuiContainer gui, VisiblityData currentVisibility);
 
@@ -23,8 +24,9 @@ public interface INEIGuiHandler {
     public List<TaggedInventoryArea> getInventoryAreas(GuiContainer gui);
 
     /**
-     * Handles clicks while an itemstack has been dragged from the item panel. Use this to set configurable slots and the like.
-     * Changes made to the stackSize of the dragged stack will be kept
+     * Handles clicks while player has ItemStack on cursor. Use this to set configurable slots and the like.
+     * Changes made to the stackSize of the dragged stack will be kept.
+     * See also {@link #handleDragNDrop(GuiContainer, int, int, ItemStack, int, ClickContext)}
      * @param gui The current gui instance
      * @param mousex The x position of the mouse
      * @param mousey The y position of the mouse
@@ -32,7 +34,25 @@ public interface INEIGuiHandler {
      * @param button The button presed
      * @return True if the drag n drop was handled. False to resume processing through other routes. The held stack will be deleted if draggedStack.stackSize == 0
      */
-    public boolean handleDragNDrop(GuiContainer gui, int mousex, int mousey, ItemStack draggedStack, int button);
+    default boolean handleDragNDrop(GuiContainer gui, int mousex, int mousey, ItemStack draggedStack, int button) {
+        return false;
+    }
+
+    /**
+     * Handles clicks while player has ItemStack on cursor. Use this to set configurable slots and the like.
+     * Changes made to the stackSize of the dragged stack will be kept.
+     * @param gui The current gui instance
+     * @param mousex The x position of the mouse
+     * @param mousey The y position of the mouse
+     * @param draggedStack The stack being dragged from the item panel
+     * @param button The button pressed
+     * @param clickContext The context this method is invoked
+     * @return True if the drag n drop was handled. False to resume processing through other routes. The held stack will be deleted if draggedStack.stackSize == 0
+     */
+    default boolean handleDragNDrop(
+            GuiContainer gui, int mousex, int mousey, ItemStack draggedStack, int button, ClickContext clickContext) {
+        return handleDragNDrop(gui, mousex, mousey, draggedStack, button);
+    }
 
     /**
      * Used to prevent the item panel from drawing on top of other gui elements.


### PR DESCRIPTION
While I'm working on implementing drag'n drop behavior with digital tanks in GT, I noticed there's no way to distinguish ItemStack that is dragged from panels or actual item. That is required to keep both behavior in one slot, locking fluid from drag'n drop and filling / emptying container with FluidDisplay click (we already have).

I have another option: Add another named method and invoke it when actual item is held.
I'm not sure which is better - most of the mods don't need to distinguish the two, but `handleDragNDrop` being invoked on normal click is not intuitive.