### PR TITLE
Fix other mods cannot mixin GuiContainer.java when NEI is loaded

### DIFF
--- a/src/main/java/codechicken/nei/asm/NEITransformer.java
+++ b/src/main/java/codechicken/nei/asm/NEITransformer.java
@@ -238,6 +238,8 @@ public class NEITransformer implements IClassTransformer {
             @Override
             public void transform(MethodNode mv) {
                 ASMHelper.logger.debug("NEI: Injecting mouseUp call");
+                //Recache asmblocks to avoid null error in dev env
+                Map<String, ASMBlock> asmblocks = ASMReader.loadResource("/assets/nei/asm/blocks.asm");
                 ASMBlock gotoBlock = asmblocks.get("n_mouseUpGoto");
                 ASMBlock needleBlock = asmblocks.get("n_mouseUp");
                 ASMBlock injectionBlock = asmblocks.get("mouseUp");

--- a/src/main/java/codechicken/nei/asm/NEITransformer.java
+++ b/src/main/java/codechicken/nei/asm/NEITransformer.java
@@ -238,11 +238,10 @@ public class NEITransformer implements IClassTransformer {
             @Override
             public void transform(MethodNode mv) {
                 ASMHelper.logger.debug("NEI: Injecting mouseUp call");
-                // Recache asmblocks to avoid null error in dev env
                 Map<String, ASMBlock> asmblocks = ASMReader.loadResource("/assets/nei/asm/blocks.asm");
-                ASMBlock gotoBlock = asmblocks.get("n_mouseUpGoto");
-                ASMBlock needleBlock = asmblocks.get("n_mouseUp");
-                ASMBlock injectionBlock = asmblocks.get("mouseUp");
+                ASMBlock gotoBlock = asmblocks.get("n_mouseUpGoto").copy();
+                ASMBlock needleBlock = asmblocks.get("n_mouseUp").copy();
+                ASMBlock injectionBlock = asmblocks.get("mouseUp").copy();
 
                 gotoBlock.mergeLabels(injectionBlock);
                 findOnce(mv.instructions, gotoBlock.list).replace(gotoBlock.list.list);

--- a/src/main/java/codechicken/nei/asm/NEITransformer.java
+++ b/src/main/java/codechicken/nei/asm/NEITransformer.java
@@ -238,7 +238,6 @@ public class NEITransformer implements IClassTransformer {
             @Override
             public void transform(MethodNode mv) {
                 ASMHelper.logger.debug("NEI: Injecting mouseUp call");
-                Map<String, ASMBlock> asmblocks = ASMReader.loadResource("/assets/nei/asm/blocks.asm");
                 ASMBlock gotoBlock = asmblocks.get("n_mouseUpGoto").copy();
                 ASMBlock needleBlock = asmblocks.get("n_mouseUp").copy();
                 ASMBlock injectionBlock = asmblocks.get("mouseUp").copy();

--- a/src/main/java/codechicken/nei/asm/NEITransformer.java
+++ b/src/main/java/codechicken/nei/asm/NEITransformer.java
@@ -238,7 +238,7 @@ public class NEITransformer implements IClassTransformer {
             @Override
             public void transform(MethodNode mv) {
                 ASMHelper.logger.debug("NEI: Injecting mouseUp call");
-                //Recache asmblocks to avoid null error in dev env
+                // Recache asmblocks to avoid null error in dev env
                 Map<String, ASMBlock> asmblocks = ASMReader.loadResource("/assets/nei/asm/blocks.asm");
                 ASMBlock gotoBlock = asmblocks.get("n_mouseUpGoto");
                 ASMBlock needleBlock = asmblocks.get("n_mouseUp");


### PR DESCRIPTION
This PR fixes [this issue](https://github.com/GTNewHorizons/Hodgepodge/pull/92) by recaching **blocks.asm** on method call

**transform** method is only called twice in the game boot process. However, the second call always fails when someone mixin GuiContainer.java.
It is because the reference of **injectionBlock** variable turns into null by mixining, and after the investigation, I found there is no way to carry over the reference after the mixining process.
So I decided to add a recache method. It does not increase load time drastically since it will only be called twice.

Side note: storing copied **asmblocks** value in the class field does not work