### PR TITLE
Fix incorrect color applied to GuiRecipeCatalyst

### DIFF
--- a/src/main/java/codechicken/nei/drawable/GuiElementDuex.java
+++ b/src/main/java/codechicken/nei/drawable/GuiElementDuex.java
@@ -3,6 +3,7 @@ package codechicken.nei.drawable;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.client.gui.GuiScreen;
+import org.lwjgl.opengl.GL11;
 
 /*
 * Taken from Mantle 1.12-1.3.3.49 under the MIT License
@@ -70,6 +71,7 @@ public class GuiElementDuex {
      */
     public int draw(int xPos, int yPos) {
         // drawModalRectWithCustomSizedTexture
+        GL11.glColor4f(1, 1, 1, 1);
         GuiScreen.func_146110_a(xPos, yPos, x, y, w, h, texW, texH);
         return w;
     }


### PR DESCRIPTION
![2022-09-19_11 19 06](https://user-images.githubusercontent.com/40035906/190940970-4ddd35fc-a5a4-4385-8771-2730666544bd.png)
