### PR TITLE
Fix stack size of permutations on PositionedStack

### DIFF
--- a/src/main/java/codechicken/nei/PositionedStack.java
+++ b/src/main/java/codechicken/nei/PositionedStack.java
@@ -43,7 +43,11 @@ public class PositionedStack {
             if (item.getItemDamage() == Short.MAX_VALUE) {
                 List<ItemStack> permutations = ItemList.itemMap.get(item.getItem());
                 if (!permutations.isEmpty()) {
-                    for (ItemStack stack : permutations) stacks.add(stack.copy());
+                    for (ItemStack stack : permutations) {
+                        ItemStack toAdd = stack.copy();
+                        toAdd.stackSize = item.stackSize;
+                        stacks.add(toAdd);
+                    }
                 } else {
                     ItemStack base = new ItemStack(item.getItem(), item.stackSize);
                     base.stackTagCompound = item.stackTagCompound;


### PR DESCRIPTION
This PR fixes stack size of permutations on PositionedStack, which was once fixed on GT5 handler but removed in https://github.com/GTNewHorizons/GT5-Unofficial/pull/1552 because I thought it was identical to NEI's (which was actually not).

Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12075
Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12090
Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12097