### PR TITLE
Require shift by default for moving items with overlaying recipe

### DIFF
--- a/src/main/java/codechicken/nei/NEIClientConfig.java
+++ b/src/main/java/codechicken/nei/NEIClientConfig.java
@@ -272,7 +272,7 @@ public class NEIClientConfig {
         API.addOption(new OptionToggleButton("inventory.jei_style_cycled_ingredients", true));
 
         tag.getTag("inventory.shift_overlay_recipe")
-                .setComment("Require holding shift to move items when overlaying recipe").getBooleanValue(false);
+                .setComment("Require holding shift to move items when overlaying recipe").getBooleanValue(true);
         API.addOption(new OptionToggleButton("inventory.shift_overlay_recipe", true));
 
         tag.getTag("tools.handler_load_from_config").setComment("ADVANCED: Load handlers from config")


### PR DESCRIPTION
People thought it's breaking existing behavior
https://discord.com/channels/181078474394566657/234936569360809996/1074500209373106236