### PR TITLE
MacOS Command key accessibility

### DIFF
--- a/src/main/java/codechicken/nei/LayoutManager.java
+++ b/src/main/java/codechicken/nei/LayoutManager.java
@@ -359,11 +359,16 @@ public class LayoutManager implements IContainerInputHandler, IContainerTooltipH
                 this.icons[2] = new DrawableBuilder("nei:textures/nei_tabbed_sprites.png", 64, 0, 16, 16).build();
             }
 
+            private boolean getIsAccessibleControlEventKey() {
+                if (Minecraft.isRunningOnMac) {
+                    return Keyboard.getEventKey() == Keyboard.KEY_LMETA || Keyboard.getEventKey() == Keyboard.KEY_RMENU;
+                }
+               return Keyboard.getEventKey() == Keyboard.KEY_LCONTROL || Keyboard.getEventKey() == Keyboard.KEY_RCONTROL;
+            }
             @Override
             public boolean onButtonPress(boolean rightclick) {
                 if (!rightclick) {
-                    if (Keyboard.getEventKeyState() && (Keyboard.getEventKey() == Keyboard.KEY_LCONTROL
-                            || Keyboard.getEventKey() == Keyboard.KEY_RCONTROL)) {
+                    if (Keyboard.getEventKeyState() && (getIsAccessibleControlEventKey())) {
                         NEIClientConfig.cycleSetting("inventory.cheatmode", 3);
                     } else {
                         if (Keyboard.getEventKeyState() && (Keyboard.getEventKey() == Keyboard.KEY_LSHIFT

--- a/src/main/java/codechicken/nei/LayoutManager.java
+++ b/src/main/java/codechicken/nei/LayoutManager.java
@@ -363,12 +363,14 @@ public class LayoutManager implements IContainerInputHandler, IContainerTooltipH
                 if (Minecraft.isRunningOnMac) {
                     return Keyboard.getEventKey() == Keyboard.KEY_LMETA || Keyboard.getEventKey() == Keyboard.KEY_RMENU;
                 }
-               return Keyboard.getEventKey() == Keyboard.KEY_LCONTROL || Keyboard.getEventKey() == Keyboard.KEY_RCONTROL;
+                return Keyboard.getEventKey() == Keyboard.KEY_LCONTROL
+                        || Keyboard.getEventKey() == Keyboard.KEY_RCONTROL;
             }
+
             @Override
             public boolean onButtonPress(boolean rightclick) {
                 if (!rightclick) {
-                    if (Keyboard.getEventKeyState() && (getIsAccessibleControlEventKey())) {
+                    if (Keyboard.getEventKeyState() && getIsAccessibleControlEventKey()) {
                         NEIClientConfig.cycleSetting("inventory.cheatmode", 3);
                     } else {
                         if (Keyboard.getEventKeyState() && (Keyboard.getEventKey() == Keyboard.KEY_LSHIFT

--- a/src/main/java/codechicken/nei/LayoutManager.java
+++ b/src/main/java/codechicken/nei/LayoutManager.java
@@ -361,7 +361,7 @@ public class LayoutManager implements IContainerInputHandler, IContainerTooltipH
 
             private boolean getIsAccessibleControlEventKey() {
                 if (Minecraft.isRunningOnMac) {
-                    return Keyboard.getEventKey() == Keyboard.KEY_LMETA || Keyboard.getEventKey() == Keyboard.KEY_RMENU;
+                    return Keyboard.getEventKey() == Keyboard.KEY_LMETA || Keyboard.getEventKey() == Keyboard.KEY_RMETA;
                 }
                 return Keyboard.getEventKey() == Keyboard.KEY_LCONTROL
                         || Keyboard.getEventKey() == Keyboard.KEY_RCONTROL;

--- a/src/main/java/codechicken/nei/NEIClientUtils.java
+++ b/src/main/java/codechicken/nei/NEIClientUtils.java
@@ -251,6 +251,9 @@ public class NEIClientUtils extends NEIServerUtils {
     }
 
     public static boolean controlKey() {
+        if (Minecraft.isRunningOnMac) {
+            return Keyboard.isKeyDown(Keyboard.KEY_LMETA) || Keyboard.isKeyDown(Keyboard.KEY_RMETA);
+        }
         return Keyboard.isKeyDown(Keyboard.KEY_LCONTROL) || Keyboard.isKeyDown(Keyboard.KEY_RCONTROL);
     }
 


### PR DESCRIPTION
This cycle button tooltip shows that "press CMD + click here" but actually it didn't work even on control key on MacOS. In JEI 1.12.2 this works properly, now it's works here too.

<img width="1122" alt="Screenshot 2023-02-28 at 02 21 57" src="https://user-images.githubusercontent.com/64744993/221719913-d161fde9-a012-48c1-8026-1887eab11bc2.png">

Also this buttons (plus and minus) now are clickable with CMD.
<img width="439" alt="Screenshot 2023-02-28 at 02 25 14" src="https://user-images.githubusercontent.com/64744993/221720307-0354f150-39b1-4329-ac4b-951f3fccf016.png">

Tested also in gtnh, seems to be fine.

<img width="634" alt="Screenshot 2023-02-28 at 03 41 03" src="https://user-images.githubusercontent.com/64744993/221735824-51def621-74fe-4978-b051-b529bfcb6e49.png">
