### PR TITLE
Allow scrolling through recipe handlers

### DIFF
--- a/src/main/java/codechicken/nei/recipe/GuiRecipe.java
+++ b/src/main/java/codechicken/nei/recipe/GuiRecipe.java
@@ -388,6 +388,8 @@ public abstract class GuiRecipe<H extends IRecipeHandler> extends GuiContainer i
         // the value of the height field will be different from in other mouseover methods, which
         // could be confusing...
 
+        if (recipeTabs.mouseScrolled(i)) return;
+
         for (int recipe : getRecipeIndices()) if (handler.mouseScrolled(this, i, recipe)) return;
 
         if (new Rectangle(guiLeft, guiTop, xSize, ySize).contains(GuiDraw.getMousePosition())) {
@@ -462,11 +464,11 @@ public abstract class GuiRecipe<H extends IRecipeHandler> extends GuiContainer i
         if (page < 0) page = (handler.numRecipes() - 1) / getRecipesPerPage();
     }
 
-    private void nextType() {
+    protected void nextType() {
         setRecipePage(++recipetype);
     }
 
-    private void prevType() {
+    protected void prevType() {
         setRecipePage(--recipetype);
     }
 

--- a/src/main/java/codechicken/nei/recipe/GuiRecipeTabs.java
+++ b/src/main/java/codechicken/nei/recipe/GuiRecipeTabs.java
@@ -1,8 +1,12 @@
 package codechicken.nei.recipe;
 
+import static codechicken.lib.gui.GuiDraw.getMousePosition;
+
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.lwjgl.input.Keyboard;
 
 import codechicken.nei.Button;
 import codechicken.nei.NEIClientConfig;
@@ -190,6 +194,24 @@ public class GuiRecipeTabs {
                 return tab.onButtonPress(mouseButton == 1);
             }
         }
+        return false;
+    }
+
+    protected boolean mouseScrolled(int i) {
+        Point mPos = getMousePosition();
+
+        // Switch recipe handler tabs if either left shift is held or the tab
+        // bar is enable and the mouse cursor is positioned over said tab bar.
+        if (Keyboard.isKeyDown(Keyboard.KEY_LSHIFT)
+                || (NEIClientConfig.areJEIStyleTabsVisible() && (mPos.x >= area.x && mPos.x <= (area.x + area.width)
+                        && mPos.y >= area.y
+                        && mPos.y <= (area.y + area.height)))) {
+            if (i < 0) guiRecipe.nextType();
+            else guiRecipe.prevType();
+
+            return true;
+        }
+
         return false;
     }
 }


### PR DESCRIPTION
You can now scroll through all the different recipe handlers while hovering over the tab bar at the top, or alternatively anywhere in the recipe GUI while holding the left shift key.

The shift key portion of this needs to be documented somewhere, probably in the wiki [here](https://gtnh.miraheze.org/wiki/Beginner_Tips#Learning_to_use_NEI).

https://github.com/GTNewHorizons/NotEnoughItems/assets/1928113/d848026e-99f9-4f02-8171-2935b123a201

