### PR TITLE
Prevent recipe handler tab scrolling from overwriting recipe handler-specific scrolling

### DIFF
--- a/src/main/java/codechicken/nei/recipe/GuiRecipe.java
+++ b/src/main/java/codechicken/nei/recipe/GuiRecipe.java
@@ -388,9 +388,9 @@ public abstract class GuiRecipe<H extends IRecipeHandler> extends GuiContainer i
         // the value of the height field will be different from in other mouseover methods, which
         // could be confusing...
 
-        if (recipeTabs.mouseScrolled(i)) return;
-
         for (int recipe : getRecipeIndices()) if (handler.mouseScrolled(this, i, recipe)) return;
+
+        if (recipeTabs.mouseScrolled(i)) return;
 
         if (new Rectangle(guiLeft, guiTop, xSize, ySize).contains(GuiDraw.getMousePosition())) {
             if (i > 0) prevPage();

--- a/src/main/java/codechicken/nei/recipe/GuiRecipeTabs.java
+++ b/src/main/java/codechicken/nei/recipe/GuiRecipeTabs.java
@@ -198,14 +198,14 @@ public class GuiRecipeTabs {
     }
 
     protected boolean mouseScrolled(int i) {
-        Point mPos = getMousePosition();
+        Point mousePosition = getMousePosition();
 
         // Switch recipe handler tabs if either left shift is held or the tab
         // bar is enable and the mouse cursor is positioned over said tab bar.
-        if (Keyboard.isKeyDown(Keyboard.KEY_LSHIFT)
-                || (NEIClientConfig.areJEIStyleTabsVisible() && (mPos.x >= area.x && mPos.x <= (area.x + area.width)
-                        && mPos.y >= area.y
-                        && mPos.y <= (area.y + area.height)))) {
+        if (Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || (NEIClientConfig.areJEIStyleTabsVisible()
+                && (mousePosition.x >= area.x && mousePosition.x <= (area.x + area.width)
+                        && mousePosition.y >= area.y
+                        && mousePosition.y <= (area.y + area.height)))) {
             if (i < 0) guiRecipe.nextType();
             else guiRecipe.prevType();
 


### PR DESCRIPTION
For example, the regular crafting recipe handler allows scrolling through all oredict options while holding down Shift (#271). This unfortunately was overwritten by the recipe handler tab scrolling implementation. To fix it we change the order in which scrolling handlers are executed.

Reported by @dragagon