### PR TITLE
Fix crash with IC2 setItemDamage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1683705740
+//version: 1684218858
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -69,7 +69,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.13.0' apply false // 6.13.0 is the last jvm8 supporting version
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.11'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.14'
 }
 
 print("You might want to check out './gradlew :faq' if your build fails.\n")
@@ -730,7 +730,7 @@ dependencies {
         java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
     }
     if (modId != 'hodgepodge') {
-        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.8')
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.13')
     }
 
     java17PatchDependencies('net.minecraft:launchwrapper:1.15') {transitive = false}

--- a/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
@@ -210,7 +210,11 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
                 for (int i = 0; i < stack.items.length; i++) {
                     if (NEIServerUtils.areStacksSameTypeCrafting(ingredient, stack.items[i])) {
                         stack.item = stack.items[i];
-                        stack.item.setItemDamage(ingredient.getItemDamage());
+                        try {
+                            stack.item.setItemDamage(ingredient.getItemDamage());
+                        } catch (Throwable ignored) {
+                            // IC2 somehow causes crash
+                        }
                         if (ingredient.hasTagCompound()) {
                             stack.item.setTagCompound((NBTTagCompound) ingredient.getTagCompound().copy());
                         }

--- a/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
 import net.minecraft.inventory.Container;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -210,11 +211,7 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
                 for (int i = 0; i < stack.items.length; i++) {
                     if (NEIServerUtils.areStacksSameTypeCrafting(ingredient, stack.items[i])) {
                         stack.item = stack.items[i];
-                        try {
-                            stack.item.setItemDamage(ingredient.getItemDamage());
-                        } catch (Throwable ignored) {
-                            // IC2 somehow causes crash
-                        }
+                        Items.feather.setDamage(stack.item, Items.feather.getDamage(ingredient));
                         if (ingredient.hasTagCompound()) {
                             stack.item.setTagCompound((NBTTagCompound) ingredient.getTagCompound().copy());
                         }


### PR DESCRIPTION
Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13500
I'm still not sure how creating (not throwing) `new Throwable()` causes crash in the pack but not in dev env