### PR TITLE
Adjust recipe handler scrolling again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1684218858
+//version: 1685785062
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -1276,12 +1276,14 @@ tasks.register('faq') {
     description = 'Prints frequently asked questions about building a project'
 
     doLast {
-        print("If your build fails to fetch dependencies, they might have been deleted and replaced by newer " +
-            "versions.\nCheck if the versions you try to fetch are still on the distributing sites.\n" +
-            "The links can be found in repositories.gradle and build.gradle:repositories, " +
-            "not build.gradle:buildscript.repositories - this one is for gradle plugin metadata.\n\n" +
+        print("If your build fails to fetch dependencies, run './gradlew updateDependencies'. " +
+            "Or you can manually check if the versions are still on the distributing sites - " +
+            "the links can be found in repositories.gradle and build.gradle:repositories, " +
+            "but not build.gradle:buildscript.repositories - those ones are for gradle plugin metadata.\n\n" +
             "If your build fails to recognize the syntax of new Java versions, enable Jabel in your " +
-            "gradle.properties. See how it's done in GTNH ExampleMod/gradle.properties.")
+            "gradle.properties. See how it's done in GTNH ExampleMod/gradle.properties. " +
+            "However, keep in mind that Jabel enables only syntax features, but not APIs that were introduced in " +
+            "Java 9 or later.")
     }
 }
 

--- a/src/main/java/codechicken/nei/recipe/GuiRecipe.java
+++ b/src/main/java/codechicken/nei/recipe/GuiRecipe.java
@@ -388,10 +388,22 @@ public abstract class GuiRecipe<H extends IRecipeHandler> extends GuiContainer i
         // the value of the height field will be different from in other mouseover methods, which
         // could be confusing...
 
-        for (int recipe : getRecipeIndices()) if (handler.mouseScrolled(this, i, recipe)) return;
-
+        // First, invoke scroll handling over recipe handler tabbar. Makes sure it is not overwritten by recipe
+        // handler-specific scroll behavior.
         if (recipeTabs.mouseScrolled(i)) return;
 
+        for (int recipe : getRecipeIndices()) if (handler.mouseScrolled(this, i, recipe)) return;
+
+        // If shift is held, try switching to the next recipe handler. Replicates the GuiRecipeTabs.mouseScrolled()
+        // without the checking for the cursor being inside the tabbar.
+        if (NEIClientUtils.shiftKey()) {
+            if (i < 0) nextType();
+            else prevType();
+
+            return;
+        }
+
+        // Finally, if nothing else has handled scrolling, try changing to the next recipe page.
         if (new Rectangle(guiLeft, guiTop, xSize, ySize).contains(GuiDraw.getMousePosition())) {
             if (i > 0) prevPage();
             else nextPage();

--- a/src/main/java/codechicken/nei/recipe/GuiRecipeTabs.java
+++ b/src/main/java/codechicken/nei/recipe/GuiRecipeTabs.java
@@ -6,8 +6,6 @@ import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.lwjgl.input.Keyboard;
-
 import codechicken.nei.Button;
 import codechicken.nei.NEIClientConfig;
 import codechicken.nei.NEIClientUtils;
@@ -200,12 +198,8 @@ public class GuiRecipeTabs {
     protected boolean mouseScrolled(int i) {
         Point mousePosition = getMousePosition();
 
-        // Switch recipe handler tabs if either left shift is held or the tab
-        // bar is enable and the mouse cursor is positioned over said tab bar.
-        if (Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || (NEIClientConfig.areJEIStyleTabsVisible()
-                && (mousePosition.x >= area.x && mousePosition.x <= (area.x + area.width)
-                        && mousePosition.y >= area.y
-                        && mousePosition.y <= (area.y + area.height)))) {
+        // Switch between recipe handlers if the cursor is over the tabbar.
+        if (NEIClientConfig.areJEIStyleTabsVisible() && area.contains(mousePosition)) {
             if (i < 0) guiRecipe.nextType();
             else guiRecipe.prevType();
 


### PR DESCRIPTION
Apologies, this is the third time now I have to tweak this functionality.

To recap, the goal is to allow switching between recipe handler while hovering over the tab bar. Additionally, recipe handler switching can be done anywhere while Shift is held down.

This moves the scroll handling over the bar to before the recipe handler-specific scroll handling to prevent it from accidentally getting consumed. Just the scroll handling while Shift is held stays in the old position after the recipe handler-specific scroll handling.