### PR TITLE
Attempt to fix CME when opening recipes immediately after load

### DIFF
--- a/src/main/java/codechicken/nei/ItemsGrid.java
+++ b/src/main/java/codechicken/nei/ItemsGrid.java
@@ -277,6 +277,10 @@ public class ItemsGrid {
     }
 
     private void drawRecipeTooltip(int mousex, int mousey, List<String> itemTooltip) {
+        if (!NEIClientConfig.isLoaded()) {
+            return;
+        }
+
         final Minecraft mc = Minecraft.getMinecraft();
         ItemPanelSlot focused = getSlotMouseOver(mousex, mousey);
         if (focused == null) {

--- a/src/main/java/codechicken/nei/api/ShortcutInputHandler.java
+++ b/src/main/java/codechicken/nei/api/ShortcutInputHandler.java
@@ -20,6 +20,10 @@ public abstract class ShortcutInputHandler {
 
     public static boolean handleKeyEvent(ItemStack stackover) {
 
+        if (!NEIClientConfig.isLoaded()) {
+            return false;
+        }
+
         if (NEIClientConfig.isKeyHashDown("gui.overlay_hide")) {
             return hideOverlayRecipe();
         }
@@ -66,6 +70,10 @@ public abstract class ShortcutInputHandler {
     }
 
     public static boolean handleMouseClick(ItemStack stackover) {
+
+        if (!NEIClientConfig.isLoaded()) {
+            return false;
+        }
 
         if (stackover != null) {
             final int button = Mouse.getEventButton();


### PR DESCRIPTION
Cancel recipe/usage open events while the config is still loading to avoid ConcurrentModificationExceptions on the handlers list.