### PR TITLE
Fix potential NPE when calling ItemMobSpawner#loadSpawners.

### DIFF
--- a/src/main/java/codechicken/nei/ItemMobSpawner.java
+++ b/src/main/java/codechicken/nei/ItemMobSpawner.java
@@ -22,8 +22,8 @@ import net.minecraftforge.client.MinecraftForgeClient;
 
 public class ItemMobSpawner extends ItemBlock {
 
-    private static Map<Integer, EntityLiving> entityHashMap;
-    private static Map<Integer, String> IDtoNameMap;
+    private static final Map<Integer, EntityLiving> entityHashMap = new HashMap<>();
+    private static final Map<Integer, String> IDtoNameMap = new HashMap<>();
     public static int idPig;
     private static boolean loaded;
 
@@ -32,9 +32,6 @@ public class ItemMobSpawner extends ItemBlock {
 
         hasSubtypes = true;
         MinecraftForgeClient.registerItemRenderer(this, new SpawnerRenderer());
-
-        entityHashMap = new HashMap<>();
-        IDtoNameMap = new HashMap<>();
     }
 
     /**


### PR DESCRIPTION
`ItemMobSpawner#loadSpawners` is static and might access `IDtoNameMap` before it is initialized in the constructor.