### PR TITLE
Holding ALT now increases bookmark stack increase in increments of output item's stack size

### DIFF
--- a/src/main/java/codechicken/nei/BookmarkPanel.java
+++ b/src/main/java/codechicken/nei/BookmarkPanel.java
@@ -1108,6 +1108,10 @@ public class BookmarkPanel extends PanelWidget {
                 final BookmarkRecipeId recipeId = BGrid.getRecipeId(slot.slotIndex);
                 final boolean addFullRecipe = NEIClientUtils.shiftKey();
 
+                if (NEIClientUtils.altKey()) {
+                    shift *= slot.item.getMaxStackSize();
+                }
+
                 if (addFullRecipe) {
                     BookmarkStackMeta iMeta;
 


### PR DESCRIPTION
This should make it a little easier to increase the stack size of a bookmark to GTNH levels of quantity. 