### PR TITLE
Hide bookmarkItemPulling button if currently opened gui is not supported

### DIFF
--- a/src/main/java/codechicken/nei/BookmarkPanel.java
+++ b/src/main/java/codechicken/nei/BookmarkPanel.java
@@ -868,8 +868,7 @@ public class BookmarkPanel extends PanelWidget {
             LayoutManager.addWidget(namespacePrev);
             LayoutManager.addWidget(namespaceNext);
             LayoutManager.addWidget(namespaceLabel);
-            if (BookmarkContainerInfo
-                    .getBookmarkContainerHandler(getGuiContainer()) != null) {
+            if (BookmarkContainerInfo.getBookmarkContainerHandler(getGuiContainer()) != null) {
                 LayoutManager.addWidget(pullBookmarkedItems);
             }
         }
@@ -1059,8 +1058,7 @@ public class BookmarkPanel extends PanelWidget {
             tooltip.add(translate("bookmark.viewmode.toggle.tip"));
         }
         if (new Rectangle4i(pullBookmarkedItems.x, pullBookmarkedItems.y, pullBookmarkedItems.w, pullBookmarkedItems.h)
-                .contains(mx, my) && BookmarkContainerInfo
-                .getBookmarkContainerHandler(getGuiContainer()) != null) {
+                .contains(mx, my) && BookmarkContainerInfo.getBookmarkContainerHandler(getGuiContainer()) != null) {
             tooltip.add(translate("bookmark.pullBookmarkedItems.tip"));
         }
 

--- a/src/main/java/codechicken/nei/BookmarkPanel.java
+++ b/src/main/java/codechicken/nei/BookmarkPanel.java
@@ -868,7 +868,10 @@ public class BookmarkPanel extends PanelWidget {
             LayoutManager.addWidget(namespacePrev);
             LayoutManager.addWidget(namespaceNext);
             LayoutManager.addWidget(namespaceLabel);
-            LayoutManager.addWidget(pullBookmarkedItems);
+            if (BookmarkContainerInfo
+                    .getBookmarkContainerHandler(getGuiContainer()) != null) {
+                LayoutManager.addWidget(pullBookmarkedItems);
+            }
         }
     }
 
@@ -1056,7 +1059,8 @@ public class BookmarkPanel extends PanelWidget {
             tooltip.add(translate("bookmark.viewmode.toggle.tip"));
         }
         if (new Rectangle4i(pullBookmarkedItems.x, pullBookmarkedItems.y, pullBookmarkedItems.w, pullBookmarkedItems.h)
-                .contains(mx, my)) {
+                .contains(mx, my) && BookmarkContainerInfo
+                .getBookmarkContainerHandler(getGuiContainer()) != null) {
             tooltip.add(translate("bookmark.pullBookmarkedItems.tip"));
         }
 


### PR DESCRIPTION
Having the button show up while a GUI is not supported will confuse the player and make him think the feature is broken. That could result in unnecessary issues being opened.

This PR hides the button if a currently opened GUI is not yet supported in the backend.

Supported GUI:
![grafik](https://github.com/GTNewHorizons/NotEnoughItems/assets/64710705/401c5776-9956-4a03-a293-09711f79e3f9)

Unsupported GUI:
![grafik](https://github.com/GTNewHorizons/NotEnoughItems/assets/64710705/67e47ae1-4460-4c40-ac83-cacef43c9c02)
