### PR TITLE
Scroll on ItemQuantityField

### DIFF
--- a/src/main/java/codechicken/nei/ItemQuantityField.java
+++ b/src/main/java/codechicken/nei/ItemQuantityField.java
@@ -52,4 +52,20 @@ public class ItemQuantityField extends TextField {
             super.draw(mousex, mousey);
         }
     }
+
+    @Override
+    public boolean onMouseWheel(int i, int mx, int my) {
+        if (!contains(mx, my)) return false;
+        int multiplier = 1;
+        if (NEIClientUtils.shiftKey()) {
+            multiplier = 10;
+        } else if (NEIClientUtils.controlKey()) {
+            multiplier = 64;
+        }
+
+        int quantity = intValue() + i * multiplier;
+        setText(Integer.toString(quantity));
+        return true;
+    }
+
 }


### PR DESCRIPTION
Add ability to scroll on ItemQuantityField. Hold `Ctrl/Cmd` to operate by 64 items, `shift` by 10 (Sync with the buttons).

**Known Issue: `shift` scroll is not working at all, which I cannot figure out why**

