### PR TITLE
Improve the way catalyst info is loaded via API

### DIFF
--- a/src/main/java/codechicken/nei/NEIClientConfig.java
+++ b/src/main/java/codechicken/nei/NEIClientConfig.java
@@ -476,7 +476,6 @@ public class NEIClientConfig {
         RecipeInfo.load();
         LayoutManager.load();
         NEIController.load();
-        RecipeCatalysts.loadCatalystInfo();
         BookmarkContainerInfo.load();
         mainNEIConfigLoaded = true;
 
@@ -501,6 +500,8 @@ public class NEIClientConfig {
                         logger.error("Failed to Load " + clazz.getName(), e);
                     }
                 }
+
+                RecipeCatalysts.loadCatalystInfo();
 
                 // Set pluginNEIConfigLoaded here before posting the NEIConfigsLoadedEvent. This used to be the other
                 // way around, but apparently if your modpack includes 800 mods the event poster might not return in

--- a/src/main/java/codechicken/nei/recipe/CatalystInfoList.java
+++ b/src/main/java/codechicken/nei/recipe/CatalystInfoList.java
@@ -10,10 +10,8 @@ import net.minecraft.item.ItemStack;
 
 import com.google.common.collect.ForwardingList;
 
-import codechicken.nei.NEIClientConfig;
 import codechicken.nei.NEIServerUtils;
 
-// Do not directly extend ArrayList, see Effective Java Item 16
 public class CatalystInfoList extends ForwardingList<CatalystInfo> {
 
     private final String handlerID;
@@ -34,16 +32,21 @@ public class CatalystInfoList extends ForwardingList<CatalystInfo> {
     }
 
     @Override
-    public boolean add(@Nonnull CatalystInfo catalystInfo) {
-        if (contains(catalystInfo)) {
-            NEIClientConfig.logger.info(
-                    String.format(
-                            "catalyst %s is already registered to handler %s",
-                            catalystInfo.getStack().getDisplayName(),
-                            handlerID));
-            return false;
+    public boolean add(@Nonnull CatalystInfo element) {
+        return doAdd(element);
+    }
+
+    public boolean add(@Nonnull CatalystInfo catalystInfo, boolean overwrite) {
+        if (overwrite || !contains(catalystInfo)) {
+            return add(catalystInfo);
         }
-        super.add(catalystInfo);
+        return false;
+    }
+
+    private boolean doAdd(@Nonnull CatalystInfo catalystInfo) {
+        catalystInfoList
+                .removeIf(c -> NEIServerUtils.areStacksSameTypeCraftingWithNBT(c.getStack(), catalystInfo.getStack()));
+        catalystInfoList.add(catalystInfo);
         return true;
     }
 


### PR DESCRIPTION
- Move `RecipeCatalysts#loadCatalystInfo` to after `IConfigureNEI` load in order to allow registering catalysts via API inside `IConfigureNEI`
- Move addition queue resolution to the beginning of `loadCatalystInfo`, while keeping removal queue at the end of config load
- Don't overwrite catalysts loaded from API and IMC if catalyst config is loaded from jar