### PR TITLE
Fix TiCo Crafting Stations not working with compressed chests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1697697256
+//version: 1698936026
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -646,7 +646,7 @@ repositories {
 
 def mixinProviderGroup = "io.github.legacymoddingmc"
 def mixinProviderModule = "unimixins"
-def mixinProviderVersion = "0.1.7.1"
+def mixinProviderVersion = "0.1.13"
 def mixinProviderSpecNoClassifer = "${mixinProviderGroup}:${mixinProviderModule}:${mixinProviderVersion}"
 def mixinProviderSpec = "${mixinProviderSpecNoClassifer}:dev"
 ext.mixinProviderSpec = mixinProviderSpec

--- a/src/main/java/codechicken/nei/recipe/DefaultOverlayHandler.java
+++ b/src/main/java/codechicken/nei/recipe/DefaultOverlayHandler.java
@@ -116,11 +116,10 @@ public class DefaultOverlayHandler implements IOverlayHandler {
                 if (!slot.getHasStack() || !canMoveFrom(slot, gui)) continue;
 
                 ItemStack stack = slot.getStack();
-                int backupStackSize = stack.stackSize; // clickSlot can kill the reference
                 if (!canStack(stack, pstack)) continue;
 
+                int amount = Math.min(transferCap - transferred, stack.stackSize);
                 FastTransferManager.clickSlot(gui, slot.slotNumber);
-                int amount = Math.min(transferCap - transferred, backupStackSize);
                 for (int c = 0; c < amount; c++) {
                     FastTransferManager.clickSlot(gui, dest.slotNumber, 1);
                     transferred++;

--- a/src/main/java/codechicken/nei/recipe/DefaultOverlayHandler.java
+++ b/src/main/java/codechicken/nei/recipe/DefaultOverlayHandler.java
@@ -116,10 +116,11 @@ public class DefaultOverlayHandler implements IOverlayHandler {
                 if (!slot.getHasStack() || !canMoveFrom(slot, gui)) continue;
 
                 ItemStack stack = slot.getStack();
+                int backupStackSize = stack.stackSize; // clickSlot can kill the reference
                 if (!canStack(stack, pstack)) continue;
 
                 FastTransferManager.clickSlot(gui, slot.slotNumber);
-                int amount = Math.min(transferCap - transferred, stack.stackSize);
+                int amount = Math.min(transferCap - transferred, backupStackSize);
                 for (int c = 0; c < amount; c++) {
                     FastTransferManager.clickSlot(gui, dest.slotNumber, 1);
                     transferred++;


### PR DESCRIPTION
The problem here is that the the `stack` of `slot` which gets picked up by the `FastTransferManager` for some reason loses it's `stacksize` in the process **IF** the chest is a compressed chest. If the chest is any other chest it works fine and the `stacksize` doesn't get set to 0. A `stacksize` of 0 causes the for-loop not to trigger, meaning this code does nothing for compressed chests.

This change creates a backup of the stacksize and uses that instead of the ItemStack `stacksize` provided in `stack`. There seems to be a problem somewhere further down the chain within the `FastTransferManager`, but I couldn't figure out at all what it might be. The `FTM.clickSlot()` method just seems to be a fancy wrapper for Mojang methods.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13034