### PR TITLE
Correctly find the recipeId under mouse when using the search

### DIFF
--- a/src/main/java/codechicken/nei/BookmarkPanel.java
+++ b/src/main/java/codechicken/nei/BookmarkPanel.java
@@ -1631,7 +1631,7 @@ public class BookmarkPanel extends PanelWidget {
                             itemStr);
                 }
 
-            } catch (IllegalArgumentException | JsonSyntaxException e) {
+            } catch (IllegalArgumentException | JsonSyntaxException | IllegalStateException e) {
                 NEIClientConfig.logger.error("Failed to load bookmarked ItemStack from json string:\n{}", itemStr);
             }
         }

--- a/src/main/java/codechicken/nei/ItemHistoryPanel.java
+++ b/src/main/java/codechicken/nei/ItemHistoryPanel.java
@@ -39,8 +39,7 @@ public class ItemHistoryPanel extends Widget {
 
     public void addItem(ItemStack stack) {
         if (stack != null) {
-            ItemStack is = stack.copy();
-            is.stackSize = 1;
+            ItemStack is = StackInfo.loadFromNBT(StackInfo.itemStackToNBT(stack), 0);
 
             grid.realItems.removeIf(historyStack -> StackInfo.equalItemAndNBT(historyStack, stack, true));
             grid.realItems.add(0, is);

--- a/src/main/java/codechicken/nei/recipe/GuiRecipe.java
+++ b/src/main/java/codechicken/nei/recipe/GuiRecipe.java
@@ -543,10 +543,11 @@ public abstract class GuiRecipe<H extends IRecipeHandler> extends GuiContainer i
     }
 
     public List<PositionedStack> getFocusedRecipeIngredients() {
+        List<Integer> indices = getRecipeIndices();
 
-        for (int recipeIndex : getRecipeIndices()) {
-            if (recipeInFocus(recipeIndex)) {
-                return handler.original.getIngredientStacks(recipeIndex);
+        for (int refIndex = 0; refIndex < indices.size(); refIndex++) {
+            if (recipeInFocus(refIndex, indices.get(refIndex))) {
+                return handler.original.getIngredientStacks(indices.get(refIndex));
             }
         }
 
@@ -554,9 +555,11 @@ public abstract class GuiRecipe<H extends IRecipeHandler> extends GuiContainer i
     }
 
     public int prepareFocusedRecipeResultStackSize(ItemStack stackover) {
+        List<Integer> indices = getRecipeIndices();
 
-        for (int recipeIndex : getRecipeIndices()) {
-            if (recipeInFocus(recipeIndex)) {
+        for (int refIndex = 0; refIndex < indices.size(); refIndex++) {
+            final int recipeIndex = indices.get(refIndex);
+            if (recipeInFocus(refIndex, recipeIndex)) {
                 final PositionedStack result = handler.original.getResultStack(recipeIndex);
                 int stackSize = 0;
 
@@ -578,15 +581,16 @@ public abstract class GuiRecipe<H extends IRecipeHandler> extends GuiContainer i
         return stackover.stackSize;
     }
 
-    protected boolean recipeInFocus(int recipeIndex) {
+    protected boolean recipeInFocus(int refIndex, int recipeIndex) {
         final PositionedStack result = handler.original.getResultStack(recipeIndex);
-        if (result != null && isMouseOver(result, recipeIndex)) {
+
+        if (result != null && isMouseOver(result, refIndex)) {
             return true;
         }
 
         final List<PositionedStack> stacks = handler.original.getOtherStacks(recipeIndex);
         for (PositionedStack stack : stacks) {
-            if (isMouseOver(stack, recipeIndex)) {
+            if (isMouseOver(stack, refIndex)) {
                 return true;
             }
         }

--- a/src/main/java/codechicken/nei/recipe/GuiRecipe.java
+++ b/src/main/java/codechicken/nei/recipe/GuiRecipe.java
@@ -546,8 +546,9 @@ public abstract class GuiRecipe<H extends IRecipeHandler> extends GuiContainer i
         List<Integer> indices = getRecipeIndices();
 
         for (int refIndex = 0; refIndex < indices.size(); refIndex++) {
-            if (recipeInFocus(refIndex, indices.get(refIndex))) {
-                return handler.original.getIngredientStacks(indices.get(refIndex));
+            final int recipeIndex = indices.get(refIndex);
+            if (recipeInFocus(refIndex, recipeIndex)) {
+                return handler.original.getIngredientStacks(recipeIndex);
             }
         }
 


### PR DESCRIPTION
1. Correctly find the recipeId under mouse when using the search
2. Catch exception when bookmarks.ini is broken (https://github.com/GTNewHorizons/NotEnoughItems/issues/464)
3. Don't save stackSize/fluidAmount in History Panel