### PR TITLE
Add Railcraft NEI handlers to height hack

### DIFF
--- a/src/main/resources/assets/nei/cfg/heighthackhandlers.cfg
+++ b/src/main/resources/assets/nei/cfg/heighthackhandlers.cfg
@@ -10,6 +10,7 @@ ic2.neiIntegration.core.recipehandler.*
 mariculture.plugins.nei.*
 redgear.brewcraft.plugins.nei.*
 tconstruct.plugins.nei.*
+tonius.neiintegration.mods.railcraft.*
 WayofTime.alchemicalWizardry.client.nei.*
 exnihilo.compatibility.nei.*
 blusunrize.immersiveengineering.client.nei.*


### PR DESCRIPTION
Add Railcraft NEI handlers to NEI defaults for height hack. As reported here:
 * https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16020

For reference, PR which updates the GTNH config:
 * https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/16030