### PR TITLE
Concurrent recipe profiler

### DIFF
--- a/src/main/java/codechicken/nei/recipe/GuiCraftingRecipe.java
+++ b/src/main/java/codechicken/nei/recipe/GuiCraftingRecipe.java
@@ -34,7 +34,9 @@ public class GuiCraftingRecipe extends GuiRecipe<ICraftingHandler> {
         final BookmarkRecipeId recipeId;
 
         if ("item".equals(outputId)) {
-            results = Arrays.asList(results).stream().map(rslt -> normalizeItemStack((ItemStack) rslt)).toArray();
+            for (int i = 0; i < results.length; i++) {
+                results[i] = normalizeItemStack((ItemStack) results[i]);
+            }
             recipeId = getRecipeId(mc.currentScreen, (ItemStack) results[0]);
         } else if ("recipeId".equals(outputId)) {
             recipeId = (BookmarkRecipeId) results[1];
@@ -103,7 +105,7 @@ public class GuiCraftingRecipe extends GuiRecipe<ICraftingHandler> {
                 "outputId: " + outputId,
                 "results: " + Arrays.toString(results));
 
-        return recipeQuery.runWithProfiling("recipe.concurrent.crafting");
+        return recipeQuery.runWithProfiling(NEIClientUtils.translate("recipe.concurrent.crafting"));
     }
 
     private static ArrayList<ICraftingHandler> filterByHandlerName(ArrayList<ICraftingHandler> craftinghandlers,

--- a/src/main/java/codechicken/nei/recipe/GuiUsageRecipe.java
+++ b/src/main/java/codechicken/nei/recipe/GuiUsageRecipe.java
@@ -18,8 +18,9 @@ public class GuiUsageRecipe extends GuiRecipe<IUsageHandler> {
     public static boolean openRecipeGui(String inputId, Object... ingredients) {
 
         if ("item".equals(inputId)) {
-            ingredients = Arrays.asList(ingredients).stream().map(ingr -> normalizeItemStack((ItemStack) ingr))
-                    .toArray();
+            for (int i = 0; i < ingredients.length; i++) {
+                ingredients[i] = normalizeItemStack((ItemStack) ingredients[i]);
+            }
         }
 
         final ArrayList<IUsageHandler> handlers = getUsageHandlers(inputId, ingredients);
@@ -52,7 +53,7 @@ public class GuiUsageRecipe extends GuiRecipe<IUsageHandler> {
                 "inputId: " + inputId,
                 "ingredients: " + Arrays.toString(ingredients));
 
-        return recipeQuery.runWithProfiling("recipe.concurrent.usage");
+        return recipeQuery.runWithProfiling(NEIClientUtils.translate("recipe.concurrent.usage"));
     }
 
     private static ItemStack normalizeItemStack(ItemStack stack) {

--- a/src/main/java/codechicken/nei/recipe/ItemsHistoryHandler.java
+++ b/src/main/java/codechicken/nei/recipe/ItemsHistoryHandler.java
@@ -81,7 +81,7 @@ class ItemsHistoryHandler implements ICraftingHandler, IUsageHandler {
 
     @Override
     public String getRecipeName() {
-        return null;
+        return "Items History";
     }
 
     @Override

--- a/src/main/java/codechicken/nei/recipe/ProfilerRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/ProfilerRecipeHandler.java
@@ -3,29 +3,26 @@ package codechicken.nei.recipe;
 import static codechicken.lib.gui.GuiDraw.drawString;
 import static codechicken.lib.gui.GuiDraw.getStringWidth;
 
-import java.text.DecimalFormat;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.inventory.Container;
 import net.minecraft.item.ItemStack;
 
-import codechicken.core.TaskProfiler;
 import codechicken.core.TaskProfiler.ProfilerResult;
 import codechicken.nei.NEIClientConfig;
 import codechicken.nei.NEIClientUtils;
 import codechicken.nei.PositionedStack;
 import codechicken.nei.api.IOverlayHandler;
 import codechicken.nei.api.IRecipeOverlayRenderer;
+import codechicken.nei.util.AsyncTaskProfiler;
 
 public class ProfilerRecipeHandler implements ICraftingHandler, IUsageHandler {
 
-    private static final TaskProfiler profiler = new TaskProfiler();
+    private static final AsyncTaskProfiler profiler = new AsyncTaskProfiler();
 
-    public static TaskProfiler getProfiler() {
-        profiler.clear();
+    public static AsyncTaskProfiler getProfiler() {
         return profiler;
     }
 
@@ -55,8 +52,7 @@ public class ProfilerRecipeHandler implements ICraftingHandler, IUsageHandler {
     @Override
     public void drawForeground(int recipe) {
         List<ProfilerResult> results = profiler.getResults();
-        for (Iterator<ProfilerResult> it = results.iterator(); it.hasNext();)
-            if (it.next().name.equals(getRecipeName())) it.remove();
+        results.removeIf(profilerResult -> getRecipeName().equals(profilerResult.name));
 
         results.sort((o1, o2) -> o1.time < o2.time ? 1 : -1);
 
@@ -65,10 +61,9 @@ public class ProfilerRecipeHandler implements ICraftingHandler, IUsageHandler {
             int y = (i % 6) * 20 + 6;
             drawString(r.name, 8, y, 0xFF808080, false);
 
-            DecimalFormat format = new DecimalFormat("0.00");
-            String s = format.format(r.fraction * 100) + "%";
-            if (r.time < 1000000L) s += " (" + (r.time / 1000) + "us)";
-            else s += " (" + (r.time / 1000000) + "ms)";
+            String s;
+            if (r.time < 1000000L) s = (r.time / 1000) + "us";
+            else s = (r.time / 1000000) + "ms";
 
             drawString(s, 156 - getStringWidth(s), y + 10, 0xFF404040, false);
         }

--- a/src/main/java/codechicken/nei/util/AsyncTaskProfiler.java
+++ b/src/main/java/codechicken/nei/util/AsyncTaskProfiler.java
@@ -1,0 +1,46 @@
+package codechicken.nei.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+
+import codechicken.core.TaskProfiler;
+
+public class AsyncTaskProfiler extends TaskProfiler {
+
+    public ThreadLocal<TaskProfiler> threadedProfiler = ThreadLocal.withInitial(TaskProfiler::new);
+
+    public Map<String, Long> times = new ConcurrentHashMap<>();
+
+    public void start(String section) {
+        threadedProfiler.get().start(section);
+    }
+
+    public void end() {
+        threadedProfiler.get().end();
+        times.putAll(threadedProfiler.get().times);
+    }
+
+    @Override
+    public List<ProfilerResult> getResults() {
+        ArrayList<ProfilerResult> results = new ArrayList<>(times.size());
+        long totalTime = times.values().stream().reduce(0L, Long::sum);
+        for (Entry<String, Long> e : times.entrySet())
+            results.add(new ProfilerResult(e.getKey(), e.getValue(), totalTime));
+        return results;
+    }
+
+    @Override
+    public void clear() {
+        if (threadedProfiler.get().currentSection != null) threadedProfiler.get().end();
+        threadedProfiler.get().clear();
+        times.clear();
+    }
+
+    public void clearCurrent() {
+        if (threadedProfiler.get().currentSection != null) threadedProfiler.get().end();
+        threadedProfiler.get().clear();
+    }
+}

--- a/src/main/java/codechicken/nei/util/AsyncTaskProfiler.java
+++ b/src/main/java/codechicken/nei/util/AsyncTaskProfiler.java
@@ -15,6 +15,7 @@ public class AsyncTaskProfiler extends TaskProfiler {
     public Map<String, Long> times = new ConcurrentHashMap<>();
 
     public void start(String section) {
+        if (section == null) section = "<unnamed>";
         threadedProfiler.get().start(section);
     }
 

--- a/src/main/resources/assets/nei/lang/en_US.lang
+++ b/src/main/resources/assets/nei/lang/en_US.lang
@@ -321,6 +321,8 @@ nei.recipe.firework.tooltip2=Multiple charges can be spawned from one rocket
 nei.recipe.brewing=Brewing
 nei.recipe.profiler.crafting=Crafting Profiling
 nei.recipe.profiler.usage=Usage Profiling
+nei.recipe.concurrent.usage=Concurrent Usage - Total
+nei.recipe.concurrent.crafting=Concurrent Crafting - Total
 
 nei.itemsort.minecraft=Minecraft
 nei.itemsort.minecraft.tip=Sorts items from vanilla minecraft first


### PR DESCRIPTION
Actually profiles every recipe handler and show them.

Now that finding both crafting and usage recipes runs in parallel, the percentage statistics are removed, but the `totalTime` field are kept for backwards compatibility.

Added the missing localization of profiler section `nei.recipe.concurrent.usage` and `nei.recipe.concurrent.usage`.

Fixed a potential performance issue, where ItemStack can be normalized in-place than an overhead of streaming operations.

Field-Tested in latest GTNH and a Reika modpack of my own.