### PR TITLE
Improve advanced search defaults

### DIFF
--- a/src/main/java/codechicken/nei/NEIClientConfig.java
+++ b/src/main/java/codechicken/nei/NEIClientConfig.java
@@ -196,7 +196,7 @@ public class NEIClientConfig {
         });
 
         tag.getTag("inventory.search.tooltipSearchMode").setComment("Search mode for Tooltips (prefix: #)")
-                .getIntValue(1);
+                .getIntValue(0);
         API.addOption(new OptionCycled("inventory.search.tooltipSearchMode", 3, true) {
 
             @Override
@@ -207,7 +207,7 @@ public class NEIClientConfig {
         });
 
         tag.getTag("inventory.search.identifierSearchMode").setComment("Search mode for identifier (prefix: &)")
-                .getIntValue(1);
+                .getIntValue(0);
         API.addOption(new OptionCycled("inventory.search.identifierSearchMode", 3, true) {
 
             @Override
@@ -218,7 +218,7 @@ public class NEIClientConfig {
         });
 
         tag.getTag("inventory.search.oreDictSearchMode").setComment("Search mode for Tag Names (prefix: $)")
-                .getIntValue(1);
+                .getIntValue(0);
         API.addOption(new OptionCycled("inventory.search.oreDictSearchMode", 3, true) {
 
             @Override
@@ -229,7 +229,7 @@ public class NEIClientConfig {
         });
 
         tag.getTag("inventory.search.subsetsSearchMode").setComment("Search mode for Item Subsets (prefix: %)")
-                .getIntValue(1);
+                .getIntValue(2);
         API.addOption(new OptionCycled("inventory.search.subsetsSearchMode", 3, true) {
 
             @Override


### PR DESCRIPTION
The original defaults were all on prefix-only which is far away from the behaviour both in NEI before and in JEI. These new ones come from a discussion in meta-dev.

These new defaults are closer to both previous NEI and JEI. They are also more straightforward for people that know nothing about it. This should drastically smooth the transition and decrease the learning curve.

new defaults:
![image](https://github.com/GTNewHorizons/NotEnoughItems/assets/40274384/812bca98-0b47-4bc7-b4e7-9abae03f7ae5)
as proposed here https://discord.com/channels/181078474394566657/939305179524792340/1255915016058835015 (also see discussion around) largely following JEI defaults.

feedback welcome.
