### PR TITLE
Disable cycle through NEI Modes if lockmode is ON

### DIFF
--- a/src/main/java/codechicken/nei/LayoutManager.java
+++ b/src/main/java/codechicken/nei/LayoutManager.java
@@ -406,7 +406,8 @@ public class LayoutManager implements IContainerInputHandler, IContainerTooltipH
             @Override
             public boolean onButtonPress(boolean rightclick) {
                 if (!rightclick) {
-                    if (Keyboard.getEventKeyState() && getIsAccessibleControlEventKey()) {
+                    if (Keyboard.getEventKeyState() && getIsAccessibleControlEventKey()
+                            && NEIClientConfig.canChangeCheatMode()) {
                         NEIClientConfig.cycleSetting("inventory.cheatmode", 3);
                     } else {
                         if (Keyboard.getEventKeyState() && (Keyboard.getEventKey() == Keyboard.KEY_LSHIFT
@@ -430,7 +431,10 @@ public class LayoutManager implements IContainerInputHandler, IContainerTooltipH
                 else if (cheatMode == 2) modeColor = EnumChatFormatting.RED.toString();
                 String controlKeyLocalization = translate(Minecraft.isRunningOnMac ? "key.ctrl.mac" : "key.ctrl");
                 tooltip.add(modeColor + translate("inventory.options.tip.cheatmode." + cheatMode));
-                tooltip.add(modeColor + translate("inventory.options.tip.cheatmode.disable", controlKeyLocalization));
+                if (NEIClientConfig.canChangeCheatMode()) {
+                    tooltip.add(
+                            modeColor + translate("inventory.options.tip.cheatmode.disable", controlKeyLocalization));
+                }
             }
 
             @Override

--- a/src/main/java/codechicken/nei/NEIClientConfig.java
+++ b/src/main/java/codechicken/nei/NEIClientConfig.java
@@ -157,7 +157,7 @@ public class NEIClientConfig {
                 return getLockedMode() == -1 || getLockedMode() == index && NEIInfo.isValidMode(index);
             }
         });
-        checkCheatMode();
+        canChangeCheatMode();
 
         tag.getTag("inventory.utilities").setDefaultValue("delete, magnet");
         API.addOption(new OptionUtilities("inventory.utilities"));
@@ -808,8 +808,13 @@ public class NEIClientConfig {
         return getIntSetting("inventory.cheatmode");
     }
 
-    private static void checkCheatMode() {
-        if (getLockedMode() != -1) setIntSetting("inventory.cheatmode", getLockedMode());
+    public static boolean canChangeCheatMode() {
+        if (getLockedMode() != -1) {
+            setIntSetting("inventory.cheatmode", getLockedMode());
+            return false;
+        }
+
+        return true;
     }
 
     public static int getLockedMode() {


### PR DESCRIPTION
It was possible to cycle through modes in NEI even though lockmode was set in the config (with CTRL+Click).
- I have disabled that if the lockmode is set based on a method in NEIClientConfig. This method also validates the property.
- Removed the tooltip with cycling if the lockmode is set (because there is no point in showing that in my opinion)

Tested on SP and on Private Server.

Fixed issue: [#17509](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17509)