### PR TITLE
replace GL immediate draw with Tessellator calls for chunk bounds rendering

### DIFF
--- a/src/main/java/codechicken/nei/WorldOverlayRenderer.java
+++ b/src/main/java/codechicken/nei/WorldOverlayRenderer.java
@@ -204,7 +204,9 @@ public class WorldOverlayRenderer implements IKeyStateTracker {
         GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
         GL11.glDisable(GL11.GL_LIGHTING);
         GL11.glLineWidth(1.5F);
-        GL11.glBegin(GL11.GL_LINES);
+
+        final Tessellator tess = Tessellator.instance;
+        tess.startDrawing(GL11.GL_LINES);
 
         for (int cx = -4; cx <= 4; cx++) for (int cz = -4; cz <= 4; cz++) {
             double x1 = ((entity.chunkCoordX + cx) << 4) - intOffsetX;
@@ -230,22 +232,22 @@ public class WorldOverlayRenderer implements IKeyStateTracker {
 
             double dist = Math.pow(1.5, -(cx * cx + cz * cz));
 
-            GL11.glColor4d(0.9, 0, 0, dist);
+            tess.setColorRGBA_F(0.9F, 0, 0, (float) dist);
             if (cx >= 0 && cz >= 0) {
-                GL11.glVertex3d(x2, y1, z2);
-                GL11.glVertex3d(x2, y2, z2);
+                tess.addVertex(x2, y1, z2);
+                tess.addVertex(x2, y2, z2);
             }
             if (cx >= 0 && cz <= 0) {
-                GL11.glVertex3d(x2, y1, z1);
-                GL11.glVertex3d(x2, y2, z1);
+                tess.addVertex(x2, y1, z1);
+                tess.addVertex(x2, y2, z1);
             }
             if (cx <= 0 && cz >= 0) {
-                GL11.glVertex3d(x1, y1, z2);
-                GL11.glVertex3d(x1, y2, z2);
+                tess.addVertex(x1, y1, z2);
+                tess.addVertex(x1, y2, z2);
             }
             if (cx <= 0 && cz <= 0) {
-                GL11.glVertex3d(x1, y1, z1);
-                GL11.glVertex3d(x1, y2, z1);
+                tess.addVertex(x1, y1, z1);
+                tess.addVertex(x1, y2, z1);
             }
 
             if (cx == 0 && cz == 0) {
@@ -266,26 +268,26 @@ public class WorldOverlayRenderer implements IKeyStateTracker {
                     y1 -= intOffsetY;
                     y2 -= intOffsetY;
 
-                    GL11.glColor4d(0, 0.9, 0, 0.4);
+                    tess.setColorRGBA_F(0, 0.9F, 0, 0.4F);
                     for (double y = (int) y1; y <= y2; y++) {
-                        GL11.glVertex3d(x2, y, z1);
-                        GL11.glVertex3d(x2, y, z2);
-                        GL11.glVertex3d(x1, y, z1);
-                        GL11.glVertex3d(x1, y, z2);
-                        GL11.glVertex3d(x1, y, z2);
-                        GL11.glVertex3d(x2, y, z2);
-                        GL11.glVertex3d(x1, y, z1);
-                        GL11.glVertex3d(x2, y, z1);
+                        tess.addVertex(x2, y, z1);
+                        tess.addVertex(x2, y, z2);
+                        tess.addVertex(x1, y, z1);
+                        tess.addVertex(x1, y, z2);
+                        tess.addVertex(x1, y, z2);
+                        tess.addVertex(x2, y, z2);
+                        tess.addVertex(x1, y, z1);
+                        tess.addVertex(x2, y, z1);
                     }
                     for (double h = 1; h <= 15; h++) {
-                        GL11.glVertex3d(x1 + h, y1, z1);
-                        GL11.glVertex3d(x1 + h, y2, z1);
-                        GL11.glVertex3d(x1 + h, y1, z2);
-                        GL11.glVertex3d(x1 + h, y2, z2);
-                        GL11.glVertex3d(x1, y1, z1 + h);
-                        GL11.glVertex3d(x1, y2, z1 + h);
-                        GL11.glVertex3d(x2, y1, z1 + h);
-                        GL11.glVertex3d(x2, y2, z1 + h);
+                        tess.addVertex(x1 + h, y1, z1);
+                        tess.addVertex(x1 + h, y2, z1);
+                        tess.addVertex(x1 + h, y1, z2);
+                        tess.addVertex(x1 + h, y2, z2);
+                        tess.addVertex(x1, y1, z1 + h);
+                        tess.addVertex(x1, y2, z1 + h);
+                        tess.addVertex(x2, y1, z1 + h);
+                        tess.addVertex(x2, y2, z1 + h);
                     }
                 } else if (chunkOverlay == 3) {
                     int gx1;
@@ -310,50 +312,50 @@ public class WorldOverlayRenderer implements IKeyStateTracker {
                     int gx2 = gx1 + 48;
                     int gz2 = gz1 + 48;
 
-                    GL11.glColor4d(0, 0.9, 0, 0.4);
+                    tess.setColorRGBA_F(0, 0.9F, 0, 0.4F);
                     for (double y = (int) y1; y <= y2; y++) {
-                        GL11.glVertex3d(gx2, y, gz1);
-                        GL11.glVertex3d(gx2, y, gz2);
-                        GL11.glVertex3d(gx1, y, gz1);
-                        GL11.glVertex3d(gx1, y, gz2);
-                        GL11.glVertex3d(gx1, y, gz2);
-                        GL11.glVertex3d(gx2, y, gz2);
-                        GL11.glVertex3d(gx1, y, gz1);
-                        GL11.glVertex3d(gx2, y, gz1);
+                        tess.addVertex(gx2, y, gz1);
+                        tess.addVertex(gx2, y, gz2);
+                        tess.addVertex(gx1, y, gz1);
+                        tess.addVertex(gx1, y, gz2);
+                        tess.addVertex(gx1, y, gz2);
+                        tess.addVertex(gx2, y, gz2);
+                        tess.addVertex(gx1, y, gz1);
+                        tess.addVertex(gx2, y, gz1);
                     }
                     for (double h = 4; h <= 44; h += 4) {
                         if (h % 16 == 0) {
                             continue;
                         }
-                        GL11.glVertex3d(gx1 + h, y1, gz1);
-                        GL11.glVertex3d(gx1 + h, y2, gz1);
-                        GL11.glVertex3d(gx1 + h, y1, gz2);
-                        GL11.glVertex3d(gx1 + h, y2, gz2);
-                        GL11.glVertex3d(gx1, y1, gz1 + h);
-                        GL11.glVertex3d(gx1, y2, gz1 + h);
-                        GL11.glVertex3d(gx2, y1, gz1 + h);
-                        GL11.glVertex3d(gx2, y2, gz1 + h);
+                        tess.addVertex(gx1 + h, y1, gz1);
+                        tess.addVertex(gx1 + h, y2, gz1);
+                        tess.addVertex(gx1 + h, y1, gz2);
+                        tess.addVertex(gx1 + h, y2, gz2);
+                        tess.addVertex(gx1, y1, gz1 + h);
+                        tess.addVertex(gx1, y2, gz1 + h);
+                        tess.addVertex(gx2, y1, gz1 + h);
+                        tess.addVertex(gx2, y2, gz1 + h);
                     }
 
-                    GL11.glColor4d(0, 0, 0.9, 0.4);
+                    tess.setColorRGBA_F(0, 0, 0.9F, 0.4F);
                     gx1 += 23;
                     gz1 += 23;
                     gx2 = gx1 + 1;
                     gz2 = gz1 + 1;
 
-                    GL11.glVertex3d(gx1, y1, gz1);
-                    GL11.glVertex3d(gx1, y2, gz1);
-                    GL11.glVertex3d(gx2, y1, gz1);
-                    GL11.glVertex3d(gx2, y2, gz1);
-                    GL11.glVertex3d(gx1, y1, gz2);
-                    GL11.glVertex3d(gx1, y2, gz2);
-                    GL11.glVertex3d(gx2, y1, gz2);
-                    GL11.glVertex3d(gx2, y2, gz2);
+                    tess.addVertex(gx1, y1, gz1);
+                    tess.addVertex(gx1, y2, gz1);
+                    tess.addVertex(gx2, y1, gz1);
+                    tess.addVertex(gx2, y2, gz1);
+                    tess.addVertex(gx1, y1, gz2);
+                    tess.addVertex(gx1, y2, gz2);
+                    tess.addVertex(gx2, y1, gz2);
+                    tess.addVertex(gx2, y2, gz2);
                 }
             }
         }
 
-        GL11.glEnd();
+        tess.draw();
         GL11.glEnable(GL11.GL_LIGHTING);
         GL11.glEnable(GL11.GL_TEXTURE_2D);
         GL11.glDisable(GL11.GL_BLEND);


### PR DESCRIPTION
The same thing was already done for the mob spawn overlay (89cc20387585694b111669401466c619460d4b1e), i don't know why it wasn't for this. 
From what i can see, this also fixes the bug that the chunk overlay is not working with angelica shaders.