### PR TITLE
Fix handler ordering config

### DIFF
--- a/src/main/java/codechicken/nei/ClientHandler.java
+++ b/src/main/java/codechicken/nei/ClientHandler.java
@@ -250,7 +250,7 @@ public class ClientHandler {
             } catch (IOException e) {}
         }, lines -> lines.map(line -> line.split(COMMA_DELIMITER)).filter(parts -> parts.length == 2).forEach(parts -> {
             String handlerId = parts[0];
-            int ordering = Integer.getInteger(parts[1], 0);
+            int ordering = Integer.parseInt(parts[1]);
             NEIClientConfig.handlerOrdering.put(handlerId, ordering);
         }));
     }


### PR DESCRIPTION
Fixes GTNewHorizons/GT-New-Horizons-Modpack#18159

#519 broke the handling order config (`/config/NEI/handlingorder.csv`) because it used the wrong function to try and parse the numbers in the files. 

This fixes the config by using the proper int parsing function. 

`Integer.getInteger` [gets the value of a system property](https://www.javatpoint.com/java-integer-getinteger-method).