### PR TITLE
Fix mob spawners spawning mobs at world 0 0 0

### DIFF
--- a/src/main/java/codechicken/nei/asm/NEITransformer.java
+++ b/src/main/java/codechicken/nei/asm/NEITransformer.java
@@ -66,16 +66,6 @@ public class NEITransformer implements IClassTransformer {
                                     "func_149689_a",
                                     "(Lnet/minecraft/world/World;IIILnet/minecraft/entity/EntityLivingBase;Lnet/minecraft/item/ItemStack;)V"),
                             asmblocks.get("spawnerPlaced")));
-
-            // Make MobSpawnerBaseLogic use getSpawnerWorld when creating new entities
-            transformer.add(
-                    new MethodReplacer(
-                            new ObfMapping(
-                                    "net/minecraft/tileentity/MobSpawnerBaseLogic",
-                                    "func_98281_h",
-                                    "()Lnet/minecraft/entity/Entity;"),
-                            asmblocks.get("d_spawnerWorld"),
-                            asmblocks.get("spawnerWorld")));
         }
 
         // Removes trailing seperators from NBTTagList/Compound.toString because OCD

--- a/src/main/resources/assets/nei/asm/blocks.asm
+++ b/src/main/resources/assets/nei/asm/blocks.asm
@@ -7,13 +7,6 @@ ILOAD 4
 PUTSTATIC codechicken/nei/ItemMobSpawner.placedZ:I
 RETURN
 
-list d_spawnerWorld
-ACONST_NULL
-
-list spawnerWorld
-ALOAD 0
-INVOKEVIRTUAL net/minecraft/tileentity/MobSpawnerBaseLogic.func_98271_a()Lnet/minecraft/world/World;
-
 list n_commaFix
 LDC *
 INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;


### PR DESCRIPTION
This method in the vanilla class `MobSpawnerBaseLogic` returns a dummy entity for the tile entity renderer to render a spinning mob inside the spawner. The entity is created with a `world = null` then in the method `func_98265_a` having a null world makes the entity not spawn in the world. However the NEI asm inexplicably adds a world to the entity making it not a dumy entity anymore and the spawner will spawn it at coordinates 0 0 0 in the world which causes hundreds of mobs to pile up.
![image](https://github.com/user-attachments/assets/bd54c53a-d48c-43a4-927b-ac5e90407389)

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14838