### PR TITLE
Optimize TooltipItemFilter; ItemFilter limited cache

### DIFF
--- a/src/main/java/codechicken/nei/guihook/GuiContainerManager.java
+++ b/src/main/java/codechicken/nei/guihook/GuiContainerManager.java
@@ -44,6 +44,7 @@ import codechicken.nei.ItemStackSet;
 import codechicken.nei.NEIClientConfig;
 import codechicken.nei.NEIClientUtils;
 import codechicken.nei.recipe.StackInfo;
+import codechicken.nei.search.TooltipFilter;
 import codechicken.nei.util.ReadableNumberConverter;
 
 public class GuiContainerManager {
@@ -53,6 +54,7 @@ public class GuiContainerManager {
         @Override
         public void onResourceManagerReload(IResourceManager p_110549_1_) {
             renderingErrorItems.clear();
+            TooltipFilter.populateSearchMap();
         }
     }
 


### PR DESCRIPTION
Hope i fixed this: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18221

1. fix TooltipItemFilter. it every search generated tooltips for items what don't exist in NEI (ex. fluids)
2. added CacheItemFilter and limited HashMap. because terminals filtered items every render. for systems with many item types it is problem

P.S. On the save that was sent to me this patch significantly sped up the search and show tooltips when terminal was filtered