### PR TITLE
Fix CME in registerRectsToGuis during plugin loading

### DIFF
--- a/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
@@ -8,13 +8,14 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
@@ -311,7 +312,7 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
 
     public static class RecipeTransferRectHandler implements IContainerInputHandler, IContainerTooltipHandler {
 
-        private static final HashMap<Class<? extends GuiContainer>, HashSet<RecipeTransferRect>> guiMap = new HashMap<>();
+        private static final Map<Class<? extends GuiContainer>, HashSet<RecipeTransferRect>> guiMap = new ConcurrentHashMap<>();
 
         public static void registerRectsToGuis(List<Class<? extends GuiContainer>> classes,
                 List<RecipeTransferRect> rects) {


### PR DESCRIPTION
fix this error (https://mclo.gs/l9oHD18) form this issue (https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18239):

![image](https://github.com/user-attachments/assets/1f2852dd-53e7-4e24-a89e-d8bb5484b4f2)

P.S. I can't reproduce crash (tried 12 times).