### PR TITLE
fix memory leak fixes not working for MP

### DIFF
--- a/src/main/java/codechicken/nei/ClientHandler.java
+++ b/src/main/java/codechicken/nei/ClientHandler.java
@@ -325,9 +325,8 @@ public class ClientHandler {
 
                 if (!Minecraft.getMinecraft().isSingleplayer()) // wait for server to initiate in singleplayer
                     NEIClientConfig.loadWorld("remote/" + ClientUtils.getServerIP().replace(':', '~'));
-
-                ItemMobSpawner.clearEntityReferences(world);
             }
+            ItemMobSpawner.clearEntityReferences(world);
 
             lastworld = world;
         }


### PR DESCRIPTION
#258 addresses the memory leak in ItemMobSpawner. Unfortunately the clean up handler is not consistently called on every world unloaded. This PR fixes this issue by moving the call out of that if block.