### PR TITLE
Change Permutation Filter

### DIFF
--- a/src/main/java/codechicken/nei/ItemList.java
+++ b/src/main/java/codechicken/nei/ItemList.java
@@ -287,7 +287,7 @@ public class ItemList {
                     .filter(
                             stack -> stack.getItem() != null && stack.getItem().delegate.name() != null
                                     && !ItemInfo.isHidden(stack))
-                    .collect(Collectors.toCollection(ArrayList::new));
+                    .collect(Collectors.toList());
         }
 
         // For optimization it generate itemslist, permutations, orders & collapsibleitems

--- a/src/main/java/codechicken/nei/ItemStackAmount.java
+++ b/src/main/java/codechicken/nei/ItemStackAmount.java
@@ -1,0 +1,119 @@
+package codechicken.nei;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+
+import codechicken.nei.recipe.StackInfo;
+
+public class ItemStackAmount {
+
+    private final Map<NBTTagCompound, Long> itemMap = new LinkedHashMap<>();
+
+    public void putAll(ItemStackAmount amounts) {
+        for (Map.Entry<NBTTagCompound, Long> entry : amounts.itemMap.entrySet()) {
+            this.itemMap.put(entry.getKey(), entry.getValue() + this.itemMap.getOrDefault(entry.getKey(), 0L));
+        }
+    }
+
+    public void add(ItemStack item) {
+        add(item, (long) StackInfo.getAmount(item));
+    }
+
+    public void add(ItemStack stack, Long value) {
+        if (stack == null || stack.getItem() == null) return;
+        final NBTTagCompound key = StackInfo.itemStackToNBT(stack, false);
+
+        this.itemMap.put(key, value + this.itemMap.getOrDefault(key, 0L));
+    }
+
+    public Long get(ItemStack stack) {
+        if (stack == null || stack.getItem() == null) return null;
+        final NBTTagCompound key = StackInfo.itemStackToNBT(stack, false);
+
+        return this.itemMap.get(key);
+    }
+
+    public void put(ItemStack stack, long value) {
+        if (stack == null || stack.getItem() == null) return;
+        final NBTTagCompound key = StackInfo.itemStackToNBT(stack, false);
+
+        this.itemMap.put(key, value);
+    }
+
+    public long getOrDefault(ItemStack stack, long defaultAmount) {
+        final Long e = get(stack);
+
+        return e == null ? defaultAmount : e;
+    }
+
+    public void clear() {
+        this.itemMap.clear();
+    }
+
+    public Long remove(ItemStack stack) {
+        if (stack == null || stack.getItem() == null) return null;
+        final NBTTagCompound key = StackInfo.itemStackToNBT(stack, false);
+
+        return this.itemMap.remove(key);
+    }
+
+    public boolean removeIf(Predicate<Map.Entry<NBTTagCompound, Long>> predicate) {
+        return this.itemMap.entrySet().removeIf(predicate);
+    }
+
+    public Set<Map.Entry<NBTTagCompound, Long>> entrySet() {
+        return this.itemMap.entrySet();
+    }
+
+    public List<ItemStack> values() {
+        List<ItemStack> list = new ArrayList<>();
+
+        for (Map.Entry<NBTTagCompound, Long> entry : this.itemMap.entrySet()) {
+            list.add(StackInfo.loadFromNBT(entry.getKey(), Math.max(0, entry.getValue())));
+        }
+
+        return list;
+    }
+
+    public int size() {
+        return this.itemMap.size();
+    }
+
+    public boolean isEmpty() {
+        return this.itemMap.isEmpty();
+    }
+
+    public static ItemStackAmount of(ItemStackAmount map) {
+        ItemStackAmount result = new ItemStackAmount();
+        result.itemMap.putAll(map.itemMap);
+        return result;
+    }
+
+    public static ItemStackAmount of(ItemStackMap<Long> map) {
+        ItemStackAmount result = new ItemStackAmount();
+
+        for (ItemStackMap.Entry<Long> entry : map.entries()) {
+            result.put(entry.key, entry.value);
+        }
+
+        return result;
+    }
+
+    public static ItemStackAmount of(Iterable<ItemStack> items) {
+        ItemStackAmount result = new ItemStackAmount();
+
+        for (ItemStack stack : items) {
+            result.add(stack);
+        }
+
+        return result;
+    }
+
+}

--- a/src/main/java/codechicken/nei/ItemStackMap.java
+++ b/src/main/java/codechicken/nei/ItemStackMap.java
@@ -9,6 +9,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -220,6 +221,19 @@ public class ItemStackMap<T> {
         DetailMap map = itemMap.get(key.getItem());
         if (map == null) itemMap.put(key.getItem(), map = new DetailMap());
         map.put(key, value);
+    }
+
+    public T computeIfAbsent(ItemStack key, Function<ItemStack, ? extends T> mappingFunction) {
+        T value;
+        if ((value = get(key)) == null) {
+            T newValue;
+            if ((newValue = mappingFunction.apply(key)) != null) {
+                put(key, newValue);
+                return newValue;
+            }
+        }
+
+        return value;
     }
 
     public void clear() {

--- a/src/main/java/codechicken/nei/LRUCache.java
+++ b/src/main/java/codechicken/nei/LRUCache.java
@@ -1,0 +1,21 @@
+package codechicken.nei;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+// Simple LRUCache
+public class LRUCache<K, V> extends LinkedHashMap<K, V> {
+
+    private final int capacity;
+
+    public LRUCache(int capacity) {
+        super(capacity, 0.75f, true);
+        this.capacity = capacity;
+    }
+
+    @Override
+    protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+        return size() > capacity;
+    }
+
+}

--- a/src/main/java/codechicken/nei/SearchTokenParser.java
+++ b/src/main/java/codechicken/nei/SearchTokenParser.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -100,16 +99,7 @@ public class SearchTokenParser {
         }
     }
 
-    private final LinkedHashMap<String, ItemFilter> filtersCache = new LinkedHashMap<>() {
-
-        private static final long serialVersionUID = 1042213947848622164L;
-
-        @Override
-        protected boolean removeEldestEntry(Map.Entry<String, ItemFilter> eldest) {
-            return size() > 20;
-        }
-    };
-
+    protected final LRUCache<String, ItemFilter> filtersCache = new LRUCache<>(20);
     protected final List<ISearchParserProvider> searchProviders;
     protected final ProvidersCache providersCache = new ProvidersCache();
     protected final Map<Character, Character> prefixRedefinitions = new HashMap<>();

--- a/src/main/java/codechicken/nei/api/DefaultOverlayRenderer.java
+++ b/src/main/java/codechicken/nei/api/DefaultOverlayRenderer.java
@@ -15,7 +15,7 @@ import codechicken.nei.guihook.GuiContainerManager;
 public class DefaultOverlayRenderer implements IRecipeOverlayRenderer {
 
     public DefaultOverlayRenderer(List<PositionedStack> ai, IStackPositioner positioner) {
-        positioner = this.positioner = positioner;
+        this.positioner = positioner;
         ingreds = new ArrayList<>();
         for (PositionedStack stack : ai) ingreds.add(stack.copy());
         ingreds = positioner.positionStacks(ingreds);

--- a/src/main/java/codechicken/nei/api/ItemInfo.java
+++ b/src/main/java/codechicken/nei/api/ItemInfo.java
@@ -134,6 +134,7 @@ public class ItemInfo {
         addInputHandlers();
         addIDDumps();
         addSearchProviders();
+        RecipeItemInputHandler.load();
         PresetsList.load();
     }
 
@@ -295,7 +296,6 @@ public class ItemInfo {
     }
 
     private static void addInputHandlers() {
-        GuiContainerManager.addInputHandler(new RecipeItemInputHandler());
         GuiContainerManager.addInputHandler(new PopupInputHandler());
     }
 

--- a/src/main/java/codechicken/nei/api/ShortcutInputHandler.java
+++ b/src/main/java/codechicken/nei/api/ShortcutInputHandler.java
@@ -5,7 +5,9 @@ import static codechicken.lib.gui.GuiDraw.getMousePosition;
 import java.awt.Point;
 import java.awt.Toolkit;
 import java.awt.datatransfer.StringSelection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
@@ -197,6 +199,10 @@ public abstract class ShortcutInputHandler {
         }
 
         return false;
+    }
+
+    public static Map<String, String> handleHotkeys(GuiContainer gui, int mousex, int mousey, ItemStack stack) {
+        return new HashMap<>();
     }
 
 }

--- a/src/main/java/codechicken/nei/recipe/BookmarkRecipeId.java
+++ b/src/main/java/codechicken/nei/recipe/BookmarkRecipeId.java
@@ -25,16 +25,16 @@ public class BookmarkRecipeId {
 
         for (Object pos : stacks) {
 
-            if (pos instanceof PositionedStack) {
-                pos = StackInfo.getItemStackWithMinimumDamage(((PositionedStack) pos).items);
+            if (pos instanceof PositionedStack item) {
+                pos = StackInfo.getItemStackWithMinimumDamage(item.items);
             }
 
-            if (pos instanceof ItemStack) {
-                pos = StackInfo.itemStackToNBT((ItemStack) pos);
+            if (pos instanceof ItemStack item) {
+                pos = StackInfo.itemStackToNBT(item);
             }
 
-            if (pos instanceof NBTTagCompound) {
-                ingredients.add((NBTTagCompound) pos);
+            if (pos instanceof NBTTagCompound item) {
+                ingredients.add(item);
             }
         }
     }

--- a/src/main/java/codechicken/nei/recipe/FillFluidContainerHandler.java
+++ b/src/main/java/codechicken/nei/recipe/FillFluidContainerHandler.java
@@ -70,8 +70,7 @@ public class FillFluidContainerHandler extends INEIGuiAdapter {
             }
 
             return FluidContainerRegistry.fillFluidContainer(fluidStack, draggedStack);
-        } else if (draggedStack.getItem() instanceof IFluidContainerItem) {
-            IFluidContainerItem item = (IFluidContainerItem) draggedStack.getItem();
+        } else if (draggedStack.getItem() instanceof IFluidContainerItem item) {
 
             if (item.getCapacity(draggedStack) > 0) {
                 item.drain(draggedStack, item.getCapacity(draggedStack), true);

--- a/src/main/java/codechicken/nei/recipe/GuiCraftingRecipe.java
+++ b/src/main/java/codechicken/nei/recipe/GuiCraftingRecipe.java
@@ -1,20 +1,19 @@
 package codechicken.nei.recipe;
 
-import static codechicken.lib.gui.GuiDraw.getMousePosition;
-
 import java.awt.Point;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.item.ItemStack;
 
+import codechicken.lib.gui.GuiDraw;
 import codechicken.nei.ItemPanel.ItemPanelSlot;
 import codechicken.nei.ItemPanels;
 import codechicken.nei.NEIClientConfig;
@@ -88,7 +87,7 @@ public class GuiCraftingRecipe extends GuiRecipe<ICraftingHandler> {
     public static ArrayList<ICraftingHandler> getCraftingHandlers(String outputId, Object... results) {
         ArrayList<ICraftingHandler> craftinghandlers = GuiCraftingRecipe.craftinghandlers;
         ArrayList<ICraftingHandler> serialCraftingHandlers = GuiCraftingRecipe.serialCraftingHandlers;
-        Function<ICraftingHandler, ICraftingHandler> recipeHandlerFunction;
+        UnaryOperator<ICraftingHandler> recipeHandlerFunction;
 
         if ("recipeId".equals(outputId)) {
             ItemStack stack = (ItemStack) results[0];
@@ -139,7 +138,7 @@ public class GuiCraftingRecipe extends GuiRecipe<ICraftingHandler> {
             }
         }
 
-        final Point mouseover = getMousePosition();
+        final Point mouseover = GuiDraw.getMousePosition();
         ItemPanelSlot panelSlot = ItemPanels.bookmarkPanel.getSlotMouseOver(mouseover.x, mouseover.y);
 
         if (panelSlot != null) {

--- a/src/main/java/codechicken/nei/recipe/GuiRecipe.java
+++ b/src/main/java/codechicken/nei/recipe/GuiRecipe.java
@@ -10,7 +10,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
-import java.util.stream.Collectors;
 
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
@@ -29,7 +28,6 @@ import org.lwjgl.opengl.GL11;
 import codechicken.lib.gui.GuiDraw;
 import codechicken.nei.Button;
 import codechicken.nei.GuiNEIButton;
-import codechicken.nei.ItemStackSet;
 import codechicken.nei.ItemsTooltipLineHandler;
 import codechicken.nei.LayoutManager;
 import codechicken.nei.NEICPH;
@@ -128,21 +126,27 @@ public abstract class GuiRecipe<H extends IRecipeHandler> extends GuiContainer i
         }
 
         public static PermutationTooltipLineHandler getInstance(PositionedStack pStack) {
-            final ItemFilter filter = TemplateRecipeHandler.getItemFilter();
-            List<ItemStack> items = Arrays.asList(pStack.items).stream().filter(filter::matches)
-                    .collect(Collectors.toCollection(ArrayList::new));
-
-            if (items.isEmpty()) {
-                items = Arrays.asList(pStack.items);
-            }
-
-            items = new ItemStackSet().addAll(items).keys();
+            final List<ItemStack> items = pStack.getFilteredPermutations();
 
             if (items.size() > 1) {
                 return new PermutationTooltipLineHandler(pStack, items);
             }
 
             return null;
+        }
+
+        @Override
+        protected void drawItem(int x, int y, ItemStack drawStack, String stackSize) {
+
+            if (StackInfo.equalItemAndNBT(drawStack, this.pStack.item, true)) {
+                GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
+                GL11.glDisable(GL11.GL_LIGHTING);
+                GL11.glDisable(GL11.GL_DEPTH_TEST);
+                GuiDraw.drawRect(x - 1, y - 1, 18, 18, 0x66555555);
+                GL11.glPopAttrib();
+            }
+
+            super.drawItem(x, y, drawStack, stackSize);
         }
 
     }
@@ -568,6 +572,10 @@ public abstract class GuiRecipe<H extends IRecipeHandler> extends GuiContainer i
         }
 
         return recipeFilter.filters.size() == 1 ? recipeFilter.filters.get(0) : recipeFilter;
+    }
+
+    public static ItemFilter getSearchItemFilter() {
+        return searchField.getFilter();
     }
 
     private void checkYShift() {

--- a/src/main/java/codechicken/nei/recipe/ItemsHistoryHandler.java
+++ b/src/main/java/codechicken/nei/recipe/ItemsHistoryHandler.java
@@ -17,8 +17,9 @@ class ItemsHistoryHandler implements ICraftingHandler, IUsageHandler {
     @Override
     public ICraftingHandler getRecipeHandler(String outputId, Object... results) {
 
-        if (NEIClientConfig.showHistoryPanelWidget() && "item".equals(outputId) && results[0] instanceof ItemStack) {
-            ItemPanels.itemPanel.historyPanel.addItem((ItemStack) results[0]);
+        if (NEIClientConfig.showHistoryPanelWidget() && "item".equals(outputId)
+                && results[0] instanceof ItemStack stack) {
+            ItemPanels.itemPanel.historyPanel.addItem(stack);
         }
 
         return null;
@@ -27,8 +28,9 @@ class ItemsHistoryHandler implements ICraftingHandler, IUsageHandler {
     @Override
     public IUsageHandler getUsageHandler(String inputId, Object... ingredients) {
 
-        if (NEIClientConfig.showHistoryPanelWidget() && "item".equals(inputId) && ingredients[0] instanceof ItemStack) {
-            ItemPanels.itemPanel.historyPanel.addItem((ItemStack) ingredients[0]);
+        if (NEIClientConfig.showHistoryPanelWidget() && "item".equals(inputId)
+                && ingredients[0] instanceof ItemStack stack) {
+            ItemPanels.itemPanel.historyPanel.addItem(stack);
         }
 
         return null;

--- a/src/main/java/codechicken/nei/recipe/RecipeInfo.java
+++ b/src/main/java/codechicken/nei/recipe/RecipeInfo.java
@@ -29,9 +29,10 @@ public class RecipeInfo {
 
         @Override
         public boolean equals(Object obj) {
-            if (!(obj instanceof OverlayKey)) return false;
-            OverlayKey key = (OverlayKey) obj;
-            return Objects.equal(ident, key.ident) && guiClass == key.guiClass;
+            if (obj instanceof OverlayKey item) {
+                return Objects.equal(ident, item.ident) && guiClass == item.guiClass;
+            }
+            return false;
         }
 
         @Override

--- a/src/main/java/codechicken/nei/recipe/RecipeItemInputHandler.java
+++ b/src/main/java/codechicken/nei/recipe/RecipeItemInputHandler.java
@@ -1,14 +1,22 @@
 package codechicken.nei.recipe;
 
+import java.util.Map;
+
 import net.minecraft.client.gui.inventory.GuiContainer;
-import net.minecraft.item.ItemStack;
 
 import codechicken.nei.ItemPanels;
 import codechicken.nei.api.ShortcutInputHandler;
 import codechicken.nei.guihook.GuiContainerManager;
 import codechicken.nei.guihook.IContainerInputHandler;
+import codechicken.nei.guihook.IContainerTooltipHandler;
 
-public class RecipeItemInputHandler implements IContainerInputHandler {
+public class RecipeItemInputHandler implements IContainerInputHandler, IContainerTooltipHandler {
+
+    public static void load() {
+        RecipeItemInputHandler recipeHandler = new RecipeItemInputHandler();
+        GuiContainerManager.addInputHandler(recipeHandler);
+        GuiContainerManager.addTooltipHandler(recipeHandler);
+    }
 
     @Override
     public boolean lastKeyTyped(GuiContainer gui, char keyChar, int keyCode) {
@@ -21,9 +29,21 @@ public class RecipeItemInputHandler implements IContainerInputHandler {
                 || ItemPanels.bookmarkPanel.contains(mousex, mousey))
             return false;
 
-        ItemStack stackover = GuiContainerManager.getStackMouseOver(gui);
+        return ShortcutInputHandler.handleMouseClick(GuiContainerManager.getStackMouseOver(gui));
+    }
 
-        return ShortcutInputHandler.handleMouseClick(stackover);
+    @Override
+    public Map<String, String> handleHotkeys(GuiContainer gui, int mousex, int mousey, Map<String, String> hotkeys) {
+
+        if ((gui instanceof GuiRecipe) || ItemPanels.itemPanel.contains(mousex, mousey)
+                || ItemPanels.bookmarkPanel.contains(mousex, mousey)
+                || ItemPanels.itemPanel.historyPanel.contains(mousex, mousey)) {
+            hotkeys.putAll(
+                    ShortcutInputHandler
+                            .handleHotkeys(gui, mousex, mousey, GuiContainerManager.getStackMouseOver(gui)));
+        }
+
+        return hotkeys;
     }
 
     @Override

--- a/src/main/resources/assets/nei/cfg/hiddenhandlers.cfg
+++ b/src/main/resources/assets/nei/cfg/hiddenhandlers.cfg
@@ -1,0 +1,2 @@
+# Each line in this file should either be a comment (line starts with '#'), handler name or handler id.
+# If you delete this file, it will be regenerated with the default handlers list.


### PR DESCRIPTION
I working for Favorites, refactoring Bookmarks Chains, Autocraft and other small features. I have extracted some of the functionality into this PR, to make it easier to test. (PR with 70 files is not a good idea)

`1` `Accepts following` tooltip:
`1.1` add selection for active item
`1.2` align `more` marker
`1.3` fix permutation items filter
![image](https://github.com/user-attachments/assets/240dfd35-95ee-4598-a21d-6246a13032f6)

`2` now the algorithm groups hotkeys by tooltip (Example from another PR. here only new algorithm)
![image](https://github.com/user-attachments/assets/6f1ba09c-6431-4c73-8349-656f8c730992)

`3` created missing `hiddenhandlers.cfg`
`4` code cleanup