### PR TITLE
Fix NC marker in recipe after fluid pattern terminal

### DIFF
--- a/src/main/java/codechicken/nei/PositionedStack.java
+++ b/src/main/java/codechicken/nei/PositionedStack.java
@@ -82,7 +82,11 @@ public class PositionedStack {
     }
 
     public PositionedStack copy() {
-        PositionedStack pStack = new PositionedStack(Arrays.asList(items), relx, rely, false);
+        PositionedStack pStack = new PositionedStack(
+                Arrays.stream(this.items).map(ItemStack::copy).toArray(ItemStack[]::new),
+                relx,
+                rely,
+                false);
         pStack.permutated = this.permutated;
         return pStack;
     }


### PR DESCRIPTION
### How to reproduce the error
| initial state | after added recipe to ME terminal |
|-|-|
| ![image](https://github.com/user-attachments/assets/32082d28-71bc-4483-817c-c32261c925c3) | ![image](https://github.com/user-attachments/assets/07f2caa7-e83b-486e-9852-99236c2e30af) |

