### PR TITLE
Add loadPluginsInParallel Option

### DIFF
--- a/src/main/java/codechicken/nei/NEIClientConfig.java
+++ b/src/main/java/codechicken/nei/NEIClientConfig.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
@@ -365,6 +366,7 @@ public class NEIClientConfig {
         tag.getTag("inventory.gridRenderingCacheMode").getIntValue(0);
         API.addOption(new OptionCycled("inventory.gridRenderingCacheMode", 3, true));
 
+        tag.getTag("loadPluginsInParallel").getBooleanValue(true);
         tag.getTag("itemLoadingTimeout").getIntValue(500);
 
         tag.getTag("command.creative").setDefaultValue("/gamemode {0} {1}");
@@ -849,8 +851,11 @@ public class NEIClientConfig {
 
                 @Override
                 public void run() {
+                    final Stream<Class<?>> stream = NEIClientConfig.getBooleanSetting("loadPluginsInParallel")
+                            ? NEIClientConfig.pluginsList.parallelStream()
+                            : NEIClientConfig.pluginsList.stream();
 
-                    NEIClientConfig.pluginsList.parallelStream().forEach(clazz -> {
+                    stream.forEach(clazz -> {
                         try {
                             IConfigureNEI config = (IConfigureNEI) clazz.getConstructor().newInstance();
                             config.loadConfig();


### PR DESCRIPTION
Some plugins from another modpacks broken if loading parallel. This PR Added Option to disable parallel loading.

P.S. for GTNH, loading plugins in parallel works 2 times faster

May be fix (need disabled loadPluginsInParallel):
https://github.com/GTNewHorizons/NotEnoughItems/issues/602
https://github.com/GTNewHorizons/NotEnoughItems/issues/597
https://github.com/GTNewHorizons/NotEnoughItems/issues/595