### PR TITLE
Don't exclude locals/frames when transforming.

### DIFF
--- a/src/main/java/codechicken/nei/asm/NEITransformer.java
+++ b/src/main/java/codechicken/nei/asm/NEITransformer.java
@@ -413,7 +413,7 @@ public class NEITransformer implements IClassTransformer {
                 if (name.equals("net.minecraftforge.oredict.OreDictionary")) {
                     ClassReader cr = new ClassReader(bytes);
                     ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-                    cr.accept(new OreDictionaryVisitor(ASM5, cw), ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
+                    cr.accept(new OreDictionaryVisitor(ASM5, cw), 0);
                     bytes = cw.toByteArray();
                 }
                 bytes = transformSubclasses(name, bytes);


### PR DESCRIPTION
It's annoying and causes the resulting bytecode to be significantly harder to read, with no obvious benefits that I see.