### PR TITLE
Too Many (Hidden) Items

### DIFF
--- a/src/main/resources/assets/nei/cfg/hiddenitems.cfg
+++ b/src/main/resources/assets/nei/cfg/hiddenitems.cfg
@@ -16,8 +16,9 @@
 #
 minecraft:portal
 minecraft:end_portal
-minecraft:fire
-minecraft:lava
+r/minecraft:fire$/
+r/minecraft:water$/
+r/minecraft:lava$/
 minecraft:mob_spawner
 minecraft:anvil !0
 minecraft:flowing_water


### PR DESCRIPTION
Use regex to fix lava buckets, fire charges, fireworks, and firework stars being hidden unintentionally. For example, `minecraft:lava` matches **minecraft:lava**_bucket. The $ in "r/minecraft:lava$/" matches the end of the string, so lava_bucket is now no longer matched and hidden.

Also hide water sources, since lava sources and flowing water/lava were hidden. It was probably not hidden before because of this problem (it would have accidentally hidden lily pads and water buckets).