### PR TITLE
allow setOverrideName to remove name overrides

### DIFF
--- a/src/main/java/codechicken/nei/api/API.java
+++ b/src/main/java/codechicken/nei/api/API.java
@@ -3,6 +3,7 @@ package codechicken.nei.api;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 import net.minecraft.block.Block;
 import net.minecraft.client.gui.inventory.GuiContainer;
@@ -164,8 +165,13 @@ public class API {
      * Add or replace the name normally shown on the item tooltip
      */
     public static void setOverrideName(ItemStack item, String name) {
-        if (!name.equals(ItemInfo.nameOverrides.get(item))) {
-            ItemInfo.nameOverrides.put(item, name);
+        String existing = ItemInfo.nameOverrides.get(item);
+        if (!Objects.equals(name, existing)) {
+            if (name == null) {
+                ItemInfo.nameOverrides.remove(item);
+            } else {
+                ItemInfo.nameOverrides.put(item, name);
+            }
             LayoutManager.markItemsDirty();
         }
     }


### PR DESCRIPTION
Used for undoable CraftTweaker NEI renames

(Upstreamed cherry-pick from https://github.com/GTMEGA/NotEnoughItems/commit/f50a804c797f189281a431c07b97461c365bdc7f)