### PR TITLE
Clear Crafting Grid after autocrafting

### DIFF
--- a/src/main/java/codechicken/nei/recipe/DefaultOverlayHandler.java
+++ b/src/main/java/codechicken/nei/recipe/DefaultOverlayHandler.java
@@ -135,6 +135,8 @@ public class DefaultOverlayHandler implements IOverlayHandler {
 
         }
 
+        clearIngredients(firstGui);
+
         return craft;
     }
 


### PR DESCRIPTION
Fixed this problem, when autocrafting craft wooden pulp more what needed

https://www.youtube.com/live/QRcgolMviEs?si=XGMdF-K7-Fh4lyzk&t=8112