### PR TITLE
Bookmarks Hotkeys: optimization thaumcraft recipes

### DIFF
--- a/src/main/java/codechicken/nei/PositionedStack.java
+++ b/src/main/java/codechicken/nei/PositionedStack.java
@@ -14,6 +14,7 @@ import net.minecraftforge.oredict.OreDictionary;
 import codechicken.nei.api.ItemFilter;
 import codechicken.nei.api.ItemInfo;
 import codechicken.nei.recipe.GuiRecipe;
+import codechicken.nei.recipe.StackInfo;
 
 /**
  * Simply an {@link ItemStack} with position. Mainly used in the recipe handlers.
@@ -145,7 +146,7 @@ public class PositionedStack {
      * NBT-friendly version of {@link #contains(ItemStack)}
      */
     public boolean containsWithNBT(ItemStack ingredient) {
-        for (ItemStack item : items) if (NEIServerUtils.areStacksSameTypeCraftingWithNBT(item, ingredient)) return true;
+        for (ItemStack item : items) if (StackInfo.equalItemAndNBT(item, ingredient, true)) return true;
 
         return false;
     }

--- a/src/main/java/codechicken/nei/api/ShortcutInputHandler.java
+++ b/src/main/java/codechicken/nei/api/ShortcutInputHandler.java
@@ -494,7 +494,7 @@ public abstract class ShortcutInputHandler {
             BookmarksGridSlot slot) {
 
         if (slot != null) {
-            return slot.getRecipeId();
+            return slot.isIngredient() ? null : slot.getRecipeId();
         } else if (ItemPanels.itemPanel.contains(mousex, mousey)
                 || ItemPanels.itemPanel.historyPanel.contains(mousex, mousey)) {
                     return FavoriteRecipes.getFavorite(stack);


### PR DESCRIPTION
1. Сreate some hotkeys (shift+c, shift+s, ...) only for recipe results (ignore ingredients)
2. Use StackInfo.equalItemAndNBT for recipe ingredients that understand thaumcraft aspects correctly