### PR TITLE
Allow handlers to hide the favorite and overlay buttons via IMC

### DIFF
--- a/src/main/java/codechicken/nei/config/IMCHandler.java
+++ b/src/main/java/codechicken/nei/config/IMCHandler.java
@@ -64,7 +64,7 @@ public class IMCHandler {
         final boolean requiresMod = tag.getBoolean("modRequired");
         final String excludedModId = tag.hasKey("excludedModId") ? tag.getString("excludedModId") : null;
 
-        if (handler.equals("") || modName.equals("") || modId.equals("")) {
+        if (handler.isEmpty() || modName.isEmpty() || modId.isEmpty()) {
             NEIClientConfig.logger.warn("Missing relevant information to registerHandlerInfo!");
             return;
         }
@@ -74,7 +74,7 @@ public class IMCHandler {
 
         HandlerInfo info = new HandlerInfo(handler, modName, modId, requiresMod, excludedModId);
         final String imageResource = tag.hasKey("imageResource") ? tag.getString("imageResource") : null;
-        if (imageResource != null && !imageResource.equals("")) {
+        if (imageResource != null && !imageResource.isEmpty()) {
             info.setImage(
                     imageResource,
                     tag.getInteger("imageX"),
@@ -84,7 +84,7 @@ public class IMCHandler {
         }
         if (!info.hasImageOrItem()) {
             final String itemName = tag.getString("itemName");
-            if (itemName != null && !itemName.equals("")) {
+            if (itemName != null && !itemName.isEmpty()) {
                 info.setItem(itemName, tag.hasKey("nbtInfo") ? tag.getString("nbtInfo") : null);
             }
         }
@@ -102,6 +102,10 @@ public class IMCHandler {
         } catch (NumberFormatException ignored) {
             NEIClientConfig.logger.info("Error setting handler dimensions for " + handler);
         }
+
+        // true if not set to false
+        info.setShowFavoritesButton(!tag.hasKey("showFavoritesButton") || tag.getBoolean("showFavoritesButton"));
+        info.setShowOverlayButton(!tag.hasKey("showOverlayButton") || tag.getBoolean("showOverlayButton"));
 
         GuiRecipeTab.handlerAdderFromIMC.remove(handler);
         GuiRecipeTab.handlerAdderFromIMC.put(handler, info);

--- a/src/main/java/codechicken/nei/recipe/HandlerInfo.java
+++ b/src/main/java/codechicken/nei/recipe/HandlerInfo.java
@@ -28,6 +28,8 @@ public class HandlerInfo {
     private int height = DEFAULT_HEIGHT;
     private int width = DEFAULT_WIDTH;
     private int maxRecipesPerPage = DEFAULT_MAX_PER_PAGE;
+    private boolean showFavoritesButton = true;
+    private boolean showOverlayButton = true;
 
     private ItemStack itemStack = null;
     private DrawableResource image = null;
@@ -110,6 +112,22 @@ public class HandlerInfo {
 
     public void setYShift(int yShift) {
         this.yShift = yShift;
+    }
+
+    public boolean getShowFavoritesButton() {
+        return this.showFavoritesButton;
+    }
+
+    public void setShowFavoritesButton(boolean showFavoritesButton) {
+        this.showFavoritesButton = showFavoritesButton;
+    }
+
+    public boolean getShowOverlayButton() {
+        return this.showOverlayButton;
+    }
+
+    public void setShowOverlayButton(boolean showOverlayButton) {
+        this.showOverlayButton = showOverlayButton;
     }
 
     public static class Builder {


### PR DESCRIPTION
These buttons don't make sense for all handlers.

The favorite button moves down to where the overlay button normally is if it's the only one:

<img width="487" height="520" alt="image" src="https://github.com/user-attachments/assets/efaf4383-d91c-4a68-bf0d-d4fa01b56a29" />

Should I add a config for users to disable the overlay button entirely?