### PR TITLE
Use || instead of | for top-level OR

### DIFF
--- a/src/main/java/codechicken/nei/SearchTextFormatter.java
+++ b/src/main/java/codechicken/nei/SearchTextFormatter.java
@@ -17,8 +17,8 @@ public class SearchTextFormatter implements TextFormatter {
     }
 
     public String format(String text) {
-        final String[] parts = (text + "| ").split("\\|");
-        StringJoiner formattedText = new StringJoiner(EnumChatFormatting.GRAY + "|");
+        final String[] parts = (text + "|| ").split("\\|\\|");
+        StringJoiner formattedText = new StringJoiner(EnumChatFormatting.GRAY + "||");
 
         for (int i = 0; i < parts.length - 1; i++) {
             final String filterText = parts[i];

--- a/src/main/java/codechicken/nei/SearchTokenParser.java
+++ b/src/main/java/codechicken/nei/SearchTokenParser.java
@@ -161,7 +161,7 @@ public class SearchTokenParser {
         filterText = EnumChatFormatting.getTextWithoutFormattingCodes(filterText).toLowerCase();
 
         return this.filtersCache.computeIfAbsent(filterText, text -> {
-            final String[] parts = text.split("\\|");
+            final String[] parts = text.split("\\|\\|");
             final List<ItemFilter> searchTokens = Arrays.stream(parts).map(this::parseSearchText).filter(s -> s != null)
                     .collect(Collectors.toList());
 


### PR DESCRIPTION
This is the easy workaround, allowing to use `|` inside of java regex, while preserving the top-level OR in the form of `||` for @#% etc. identifiers. 

I guess it might require some change in the gtnh context, adjusting the quest description. Also might confuse some people, why their search stopped working. May be controversial, idk.

But alas, a really huge change for regex users imo. Hopefully I didn't miss anything.