### PR TITLE
feat(moboverlay): add chat message (on/off)

### DIFF
--- a/src/main/java/codechicken/nei/WorldOverlayRenderer.java
+++ b/src/main/java/codechicken/nei/WorldOverlayRenderer.java
@@ -38,7 +38,11 @@ public class WorldOverlayRenderer implements IKeyStateTracker {
     public void tickKeyStates() {
         if (Minecraft.getMinecraft().currentScreen != null) return;
 
-        if (KeyManager.keyStates.get("world.moboverlay").down) mobOverlay = (mobOverlay + 1) % 2;
+        if (KeyManager.keyStates.get("world.moboverlay").down) {
+            mobOverlay = (mobOverlay + 1) % 2;
+            NEIClientUtils
+                    .printChatMessage(new ChatComponentText(NEIClientUtils.translate("chat.moboverlay." + mobOverlay)));
+        }
         if (KeyManager.keyStates.get("world.chunkoverlay").down) {
             chunkOverlay = (chunkOverlay + 1) % (NEIModContainer.isGT5Loaded() ? 4 : 3);
             // 0-2 (or 3 with gt)

--- a/src/main/resources/assets/nei/lang/en_US.lang
+++ b/src/main/resources/assets/nei/lang/en_US.lang
@@ -137,6 +137,8 @@ nei.chat.chunkoverlay.0=Chunk Overlay: Off
 nei.chat.chunkoverlay.1=Chunk Overlay: Chunk Corners
 nei.chat.chunkoverlay.2=Chunk Overlay: Chunks
 nei.chat.chunkoverlay.3=Chunk Overlay: GT Ore Veins
+nei.chat.moboverlay.0=Mob Spawning Overlay: §cOff
+nei.chat.moboverlay.1=Mob Spawning Overlay: §2On
 nei.chat.item_link.text=<%s> §6Click to add bookmark: %s
 nei.chat.bookmark_added.text=Bookmark added!
 


### PR DESCRIPTION
If you are in a non-spawning zone and spam your F7 keys, you can't really know if the MobOverlay is On or Off

(And why Chunk Overlay had it but not this one ?)

<img width="231" height="64" alt="image" src="https://github.com/user-attachments/assets/649e3de3-c3c8-4e12-b854-fe7f3c945dd0" />
