### PR TITLE
Potential Poppet Fix

### DIFF
--- a/src/main/java/codechicken/nei/ItemStackMap.java
+++ b/src/main/java/codechicken/nei/ItemStackMap.java
@@ -32,9 +32,16 @@ public class ItemStackMap<T> {
             if (tag != null && tag.hasNoTags()) {
                 tag = null;
             }
-            this.hashCode = Objects.hashCode(damage, tag);
+
+            NBTTagCompound snap;
+            try {
+                snap = tag == null ? null : (NBTTagCompound) tag.copy();
+            } catch (Throwable t) {
+                snap = null;
+            }
+            this.hashCode = damage;
             this.damage = damage;
-            this.tag = tag;
+            this.tag = snap;
         }
 
         public StackMetaKey(ItemStack key) {

--- a/src/main/java/codechicken/nei/ItemStackMap.java
+++ b/src/main/java/codechicken/nei/ItemStackMap.java
@@ -39,7 +39,7 @@ public class ItemStackMap<T> {
             } catch (Throwable t) {
                 snap = null;
             }
-            this.hashCode = damage;
+            this.hashCode = Objects.hashCode(damage, snap);
             this.damage = damage;
             this.tag = snap;
         }

--- a/src/main/java/codechicken/nei/ItemStackMap.java
+++ b/src/main/java/codechicken/nei/ItemStackMap.java
@@ -15,12 +15,18 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import com.google.common.base.Objects;
 
 /**
  * A maplike class for ItemStack keys with wildcard damage/NBT. Optimised for lookup
  */
 public class ItemStackMap<T> {
+
+    private static final Logger LogIt = LogManager.getLogger("NEI.ItemStackMap");
+    private static boolean snapWarning = false;
 
     public static class StackMetaKey {
 
@@ -38,6 +44,14 @@ public class ItemStackMap<T> {
                 snap = tag == null ? null : (NBTTagCompound) tag.copy();
             } catch (Throwable t) {
                 snap = null;
+                if (!snapWarning) {
+                    snapWarning = true;
+                    LogIt.warn(
+                            "[NEI] NBT snapshot failed in StackMetaKey (damage {}); "
+                                    + "falling back to no NBT in hash. This suggests a mod mutating NBT during search.",
+                            damage,
+                            t);
+                }
             }
             this.hashCode = Objects.hashCode(damage, snap);
             this.damage = damage;


### PR DESCRIPTION
Hopefully this can fix this issue Lol.... I'm hoping I'm onto something here but we will need vast testing over many instances to be sure.

Okay so essentially (pardon this botched explanation), from what I gathered from the logs this is an issue pertaining to a corrupted Object2ObjectOpenHashMap because when this.hashCode = Objects.hashCode(damage, tag); was pulling an NBT from a tooltip to match the NBT could be mutable and potentially racing. This fix essentially holds it in place by taking a snapshot so it's immutable and also checks and nulls any possible racing condition.

I think this should theoretically fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20296 I haven't had the bug reoccur since, and most importantly this code change if anything is just a positive and secure addition so there is no harm in adding it. Let's see what happens

If it does work thank you @Kynake for the insight 