### PR TITLE
Fix pressing '2' when hovering crafting output not putting the crafted item(s) in the hotbar

### DIFF
--- a/src/main/java/codechicken/nei/NEIController.java
+++ b/src/main/java/codechicken/nei/NEIController.java
@@ -138,7 +138,7 @@ public class NEIController implements IContainerSlotClickHandler, IContainerInpu
             return true;
         }
 
-        if (button == 1 && slot instanceof SlotCrafting) // right click
+        if (button == 1 && modifier != 2 && slot instanceof SlotCrafting) // right click
         {
             for (int i1 = 0; i1 < 64; i1++) // click this slot 64 times
                 manager.handleSlotClick(slot.slotNumber, button, 0);


### PR DESCRIPTION
In the code, it was not being checked if 'modifier' is equal to 2, when it is equal to 2 it means 'button' represents the keyboard keys 1-9. This made it so pressing the 2 key would be misinterpreted as a right click, resulting in undesired behavior.