### PR TITLE
Speedup rendering

### DIFF
--- a/src/main/java/codechicken/nei/ItemZoom.java
+++ b/src/main/java/codechicken/nei/ItemZoom.java
@@ -58,7 +58,7 @@ public class ItemZoom extends Widget implements IContainerInputHandler {
 
             GL11.glPopMatrix();
 
-            GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
+            GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
             GuiContainerManager.enable2DRender();
 
             if (NEIClientConfig.getBooleanSetting("inventory.itemzoom.showName")) {

--- a/src/main/java/codechicken/nei/ItemZoom.java
+++ b/src/main/java/codechicken/nei/ItemZoom.java
@@ -58,7 +58,7 @@ public class ItemZoom extends Widget implements IContainerInputHandler {
 
             GL11.glPopMatrix();
 
-            GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
+            GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT);
             GuiContainerManager.enable2DRender();
 
             if (NEIClientConfig.getBooleanSetting("inventory.itemzoom.showName")) {

--- a/src/main/java/codechicken/nei/ItemsGrid.java
+++ b/src/main/java/codechicken/nei/ItemsGrid.java
@@ -52,7 +52,7 @@ public abstract class ItemsGrid<T extends ItemsGrid.ItemsGridSlot, M extends Ite
         }
 
         public void captureScreen(Runnable callback, int mode) {
-            GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
+            GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT);
 
             resetFramebuffer();
             this.framebuffer.bindFramebuffer(false);

--- a/src/main/java/codechicken/nei/ItemsGrid.java
+++ b/src/main/java/codechicken/nei/ItemsGrid.java
@@ -52,7 +52,7 @@ public abstract class ItemsGrid<T extends ItemsGrid.ItemsGridSlot, M extends Ite
         }
 
         public void captureScreen(Runnable callback, int mode) {
-            GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
+            GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
 
             resetFramebuffer();
             this.framebuffer.bindFramebuffer(false);

--- a/src/main/java/codechicken/nei/ItemsTooltipLineHandler.java
+++ b/src/main/java/codechicken/nei/ItemsTooltipLineHandler.java
@@ -100,7 +100,7 @@ public class ItemsTooltipLineHandler implements ITooltipLineHandler {
 
         fontRenderer.drawStringWithShadow(this.labelColor + this.label + ":", x, y, 0);
 
-        GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
+        GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT);
         GL11.glPushMatrix();
         RenderHelper.enableGUIStandardItemLighting();
 

--- a/src/main/java/codechicken/nei/ItemsTooltipLineHandler.java
+++ b/src/main/java/codechicken/nei/ItemsTooltipLineHandler.java
@@ -100,7 +100,7 @@ public class ItemsTooltipLineHandler implements ITooltipLineHandler {
 
         fontRenderer.drawStringWithShadow(this.labelColor + this.label + ":", x, y, 0);
 
-        GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
+        GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
         GL11.glPushMatrix();
         RenderHelper.enableGUIStandardItemLighting();
 

--- a/src/main/java/codechicken/nei/SubsetWidget.java
+++ b/src/main/java/codechicken/nei/SubsetWidget.java
@@ -788,7 +788,7 @@ public class SubsetWidget extends Button implements ItemFilterProvider, IContain
 
             root.resize(screen, parent, dropRight);
 
-            GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
+            GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
             GuiContainerManager.enable2DRender();
             GuiContainerManager.drawItems.zLevel += 100;
 

--- a/src/main/java/codechicken/nei/SubsetWidget.java
+++ b/src/main/java/codechicken/nei/SubsetWidget.java
@@ -788,7 +788,7 @@ public class SubsetWidget extends Button implements ItemFilterProvider, IContain
 
             root.resize(screen, parent, dropRight);
 
-            GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
+            GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT);
             GuiContainerManager.enable2DRender();
             GuiContainerManager.drawItems.zLevel += 100;
 

--- a/src/main/java/codechicken/nei/api/DefaultOverlayRenderer.java
+++ b/src/main/java/codechicken/nei/api/DefaultOverlayRenderer.java
@@ -24,7 +24,7 @@ public class DefaultOverlayRenderer implements IRecipeOverlayRenderer {
 
     @Override
     public void renderOverlay(GuiContainerManager gui, Slot slot) {
-        GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
+        GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT);
         GL11.glEnable(GL11.GL_BLEND);
         GL11.glBlendFunc(770, 1);
 

--- a/src/main/java/codechicken/nei/api/DefaultOverlayRenderer.java
+++ b/src/main/java/codechicken/nei/api/DefaultOverlayRenderer.java
@@ -24,7 +24,7 @@ public class DefaultOverlayRenderer implements IRecipeOverlayRenderer {
 
     @Override
     public void renderOverlay(GuiContainerManager gui, Slot slot) {
-        GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
+        GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
         GL11.glEnable(GL11.GL_BLEND);
         GL11.glBlendFunc(770, 1);
 

--- a/src/main/java/codechicken/nei/config/OptionUtilities.java
+++ b/src/main/java/codechicken/nei/config/OptionUtilities.java
@@ -47,7 +47,7 @@ public class OptionUtilities extends OptionStringSet {
         LayoutManager.drawIcon(x + 4, 4, new Image(132, 12, 12, 12));
         x += 24;
 
-        GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
+        GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT);
         RenderHelper.enableGUIStandardItemLighting();
         GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         ItemStack sword = new ItemStack(Items.diamond_sword);

--- a/src/main/java/codechicken/nei/config/OptionUtilities.java
+++ b/src/main/java/codechicken/nei/config/OptionUtilities.java
@@ -47,7 +47,7 @@ public class OptionUtilities extends OptionStringSet {
         LayoutManager.drawIcon(x + 4, 4, new Image(132, 12, 12, 12));
         x += 24;
 
-        GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
+        GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
         RenderHelper.enableGUIStandardItemLighting();
         GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         ItemStack sword = new ItemStack(Items.diamond_sword);

--- a/src/main/java/codechicken/nei/guihook/GuiContainerManager.java
+++ b/src/main/java/codechicken/nei/guihook/GuiContainerManager.java
@@ -404,7 +404,7 @@ public class GuiContainerManager {
 
     public static void enableMatrixStackLogging() {
         if (!contextEnabled) {
-            GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
+            GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
             modelviewDepth = GL11.glGetInteger(GL11.GL_MODELVIEW_STACK_DEPTH);
             contextEnabled = true;
         }

--- a/src/main/java/codechicken/nei/guihook/GuiContainerManager.java
+++ b/src/main/java/codechicken/nei/guihook/GuiContainerManager.java
@@ -404,7 +404,7 @@ public class GuiContainerManager {
 
     public static void enableMatrixStackLogging() {
         if (!contextEnabled) {
-            GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
+            GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT);
             modelviewDepth = GL11.glGetInteger(GL11.GL_MODELVIEW_STACK_DEPTH);
             contextEnabled = true;
         }

--- a/src/main/java/codechicken/nei/recipe/RecipeTooltipLineHandler.java
+++ b/src/main/java/codechicken/nei/recipe/RecipeTooltipLineHandler.java
@@ -66,7 +66,7 @@ public class RecipeTooltipLineHandler implements ITooltipLineHandler {
         GL11.glPushMatrix();
         GL11.glScaled(1, 1, 3);
         GL11.glTranslatef(x, y, 0);
-        GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
+        GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT);
         RenderHelper.disableStandardItemLighting();
 
         this.gui.drawGuiContainerBackgroundLayer(0.0f, -100, -100);
@@ -74,7 +74,7 @@ public class RecipeTooltipLineHandler implements ITooltipLineHandler {
         GL11.glPopAttrib();
 
         if (this.gui.slotcontainer != null) {
-            GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
+            GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT);
             RenderHelper.enableGUIStandardItemLighting();
             GL11.glEnable(GL12.GL_RESCALE_NORMAL);
             GL11.glDisable(GL11.GL_DEPTH_TEST);

--- a/src/main/java/codechicken/nei/recipe/RecipeTooltipLineHandler.java
+++ b/src/main/java/codechicken/nei/recipe/RecipeTooltipLineHandler.java
@@ -66,7 +66,7 @@ public class RecipeTooltipLineHandler implements ITooltipLineHandler {
         GL11.glPushMatrix();
         GL11.glScaled(1, 1, 3);
         GL11.glTranslatef(x, y, 0);
-        GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
+        GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
         RenderHelper.disableStandardItemLighting();
 
         this.gui.drawGuiContainerBackgroundLayer(0.0f, -100, -100);
@@ -74,7 +74,7 @@ public class RecipeTooltipLineHandler implements ITooltipLineHandler {
         GL11.glPopAttrib();
 
         if (this.gui.slotcontainer != null) {
-            GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
+            GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
             RenderHelper.enableGUIStandardItemLighting();
             GL11.glEnable(GL12.GL_RESCALE_NORMAL);
             GL11.glDisable(GL11.GL_DEPTH_TEST);


### PR DESCRIPTION
Changes all mentions of GL_ALL_ATTRIB_BITS to GL_ENABLE_BIT | GL_COLOR_BUFFER_BIT

This reduces the overhead by a ton and should still remain functionally the same. I've seen ~15-20% performance increases with this simple change.