### PR TITLE
Fix tooltip item lighting

### DIFF
--- a/src/main/java/codechicken/nei/ItemsTooltipLineHandler.java
+++ b/src/main/java/codechicken/nei/ItemsTooltipLineHandler.java
@@ -92,7 +92,6 @@ public class ItemsTooltipLineHandler implements ITooltipLineHandler {
         this.labelColor = color;
     }
 
-
     @Override
     public void draw(int x, int y) {
         if (this.length == 0) return;


### PR DESCRIPTION
Fixes lighting being calculated wrong on the sides and a bug where normals don't get rescaled, causing lighting to be way off (this is technically a bug with angelica, will be fixed there aswell)

Note: I noticed something similar getting called in the RecipeTooltipLineHandler, but i have no idea where it gets called. If anyone knows if the lighting is broken there, lmk and i can fix it aswell.

Before (taken by SLPrime):
<img width="279" height="307" alt="image" src="https://github.com/user-attachments/assets/b2a17e12-fffa-4bcc-a313-243d11b54503" />

After:
<img width="380" height="502" alt="2025-10-12_21 12 04" src="https://github.com/user-attachments/assets/54632915-1bae-49f3-b263-ec1d485160da" />
