### PR TITLE
Fix recipe tooltip lighting

### DIFF
--- a/src/main/java/codechicken/nei/ItemsTooltipLineHandler.java
+++ b/src/main/java/codechicken/nei/ItemsTooltipLineHandler.java
@@ -107,7 +107,7 @@ public class ItemsTooltipLineHandler implements ITooltipLineHandler {
 
         final int xTranslation = x;
         final int yTranslation = y + fontRenderer.FONT_HEIGHT + 2;
-        final int zTranslation = 400;
+        final int zTranslation = GuiContainerManager.TOOLTIP_Z_OFFSET;
         GL11.glTranslatef(xTranslation, yTranslation, zTranslation);
 
         int indexShift = 0;

--- a/src/main/java/codechicken/nei/guihook/GuiContainerManager.java
+++ b/src/main/java/codechicken/nei/guihook/GuiContainerManager.java
@@ -82,6 +82,9 @@ public class GuiContainerManager {
     public static final LinkedList<IContainerSlotClickHandler> slotClickHandlers = new HideousLinkedList<>(
             new CopyOnWriteArrayList<>());
 
+    // Any item rendered with this z offset should render it on top of every other gui element
+    public static final int TOOLTIP_Z_OFFSET = 400;
+
     static {
         addSlotClickHandler(new DefaultSlotClickHandler());
     }

--- a/src/main/java/codechicken/nei/recipe/RecipeTooltipLineHandler.java
+++ b/src/main/java/codechicken/nei/recipe/RecipeTooltipLineHandler.java
@@ -80,10 +80,10 @@ public class RecipeTooltipLineHandler implements ITooltipLineHandler {
 
         final Dimension size = getSize();
 
-        GL11.glPushMatrix();
         GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT | GL11.GL_LIGHTING_BIT);
-        GL11.glTranslatef(x, y, 0);
-        GL11.glScaled(1, 1, 3);
+
+        final int zTranslation = GuiContainerManager.TOOLTIP_Z_OFFSET;
+        GL11.glTranslatef(x, y, zTranslation);
 
         GuiContainerManager.enable2DRender();
         GL11.glColor4f(1, 1, 1, 1);
@@ -103,7 +103,7 @@ public class RecipeTooltipLineHandler implements ITooltipLineHandler {
                 () -> { this.widget.draw(0, 0); });
 
         GL11.glPopAttrib();
-        GL11.glPopMatrix();
+        GL11.glTranslatef(-x, -y, -zTranslation);
     }
 
 }


### PR DESCRIPTION
Follow-up from https://github.com/GTNewHorizons/NotEnoughItems/pull/755

Now properly applies lighting to the recipe tooltip blocks

<img width="328" height="304" alt="image" src="https://github.com/user-attachments/assets/ec7a6b50-e798-4457-baa5-430cd765fd60" />