### PR TITLE
Fix another race condition, affecting IndustrialGrafter

### DIFF
--- a/src/main/java/codechicken/nei/ItemList.java
+++ b/src/main/java/codechicken/nei/ItemList.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
@@ -308,7 +309,13 @@ public class ItemList {
             action.run();
 
             if (stack.hasTagCompound() && hashOld != stack.stackTagCompound.hashCode()) {
-                FMLLog.warning("NEI: Forced tag update with reason (" + reason + ") for " + stack + "(" + stack.getItem() + ")");
+                FMLLog.warning(
+                        "NEI: Forced tag update with reason (" + reason
+                                + ") for "
+                                + stack
+                                + "("
+                                + stack.getItem()
+                                + ")");
             }
         }
 


### PR DESCRIPTION
This item sets a tag compound during rendering, which most likely causes the issue.

We end up in https://github.com/GTNewHorizons/bdlib/blob/870d288f830396af6f7d507e76d96972efd00f86/src/main/scala/net/bdew/lib/power/ItemPoweredBase.scala#L22 which sets the tagcompound.

I worked around it like I did with the other cases.

Stacktrace:
```
at net.bdew.lib.power.ItemPoweredBase$class.getCharge(ItemPoweredBase.scala:22)
at net.bdew.gendustry.items.IndustrialGrafter$.getCharge(IndustrialGrafter.scala:30)
at net.bdew.gendustry.power.ItemPoweredEUManager.getCharge(ItemPoweredEUManager.scala:54)
at ic2.core.item.GatewayElectricItemManager.getCharge(GatewayElectricItemManager.java:34)
at com.caedis.duradisplay.overlay.OverlayCharge.handleIElectricItem(OverlayCharge.java:67)
at com.caedis.duradisplay.overlay.OverlayCharge$$Lambda$3246/0x00007f328ea18b18.apply(Unknown Source:-1)
at com.caedis.duradisplay.overlay.OverlayDurabilityLike.getDurabilityLikeInfo(OverlayDurabilityLike.java:61)
at com.caedis.duradisplay.overlay.OverlayDurabilityLike.getRenderer(OverlayDurabilityLike.java:82)
at com.caedis.duradisplay.render.DurabilityRenderer.Render(DurabilityRenderer.java:35)
at net.minecraft.client.renderer.entity.RenderItem.redirect$zbf000$duradisplay$showDurabilityBar(MixinRenderItem.java:31)
at net.minecraft.client.renderer.entity.RenderItem.func_94148_a(RenderItem.java:691)
at codechicken.nei.guihook.GuiContainerManager.lambda$drawItem$0(GuiContainerManager.java:351)
at codechicken.nei.guihook.GuiContainerManager$$Lambda$6266/0x00007f328f78b4e8.run(Unknown Source:-1)
at codechicken.nei.guihook.GuiContainerManager.safeItemRenderContext(GuiContainerManager.java:380)
at codechicken.nei.guihook.GuiContainerManager.drawItem(GuiContainerManager.java:318)
at codechicken.nei.guihook.GuiContainerManager.drawItem(GuiContainerManager.java:304)
at codechicken.nei.ItemsGrid$ItemsGridSlot.drawItem(ItemsGrid.java:195)
at codechicken.nei.ItemsGrid$ItemsGridSlot.drawItem(ItemsGrid.java:180)
at codechicken.nei.ItemsPanelGrid$ItemsPanelGridSlot.drawItem(ItemsPanelGrid.java:66)
at codechicken.nei.ItemsGrid.drawItems(ItemsGrid.java:521)
at codechicken.nei.ItemsGrid.draw(ItemsGrid.java:557)
at codechicken.nei.ItemsPanelGrid.draw(ItemsPanelGrid.java:243)
at codechicken.nei.PanelWidget.draw(PanelWidget.java:158)
at codechicken.nei.LayoutManager.renderObjects(LayoutManager.java:278)
at codechicken.nei.guihook.GuiContainerManager.renderObjects(GuiContainerManager.java:571)
```