### PR TITLE
Fix missing favorites and incorrect crafting chains for recipes with identical ingredients

### DIFF
--- a/src/main/java/codechicken/nei/recipe/Recipe.java
+++ b/src/main/java/codechicken/nei/recipe/Recipe.java
@@ -236,6 +236,12 @@ public class Recipe {
                     return false;
                 }
 
+                if (isShapedRecipe() && this.result != null
+                        && anRecipeId.result != null
+                        && !StackInfo.equalItemAndNBT(this.result, anRecipeId.result, true)) {
+                    return false;
+                }
+
                 for (int idx = 0; idx < this.ingredients.size(); idx++) {
                     if (!StackInfo.equalItemAndNBT(this.ingredients.get(idx), anRecipeId.ingredients.get(idx), true)) {
                         return false;


### PR DESCRIPTION
closed: https://github.com/GTNewHorizons/NotEnoughItems/issues/813