### PR TITLE
Restore the 'get infinite items' action

### DIFF
--- a/src/main/java/codechicken/nei/NEIClientUtils.java
+++ b/src/main/java/codechicken/nei/NEIClientUtils.java
@@ -204,7 +204,7 @@ public class NEIClientUtils extends NEIServerUtils {
     public static void cheatItem(ItemStack stack, int button, int mode) {
         if (!canCheatItem(stack)) return;
 
-        if (mode == -1 && button == 0 && shiftKey() && NEIClientConfig.hasSMPCounterPart()) {
+        if (mode == -1 && button == 0 && controlKey() && NEIClientConfig.hasSMPCounterPart()) {
             for (IInfiniteItemHandler handler : ItemInfo.infiniteHandlers) {
                 if (!handler.canHandleItem(stack)) continue;
 

--- a/src/main/java/codechicken/nei/api/ShortcutInputHandler.java
+++ b/src/main/java/codechicken/nei/api/ShortcutInputHandler.java
@@ -585,6 +585,9 @@ public abstract class ShortcutInputHandler {
             hotkeys.put(
                     NEIClientUtils.getKeyName(NEIClientUtils.SHIFT_HASH, NEIMouseUtils.MOUSE_BTN_RMB),
                     NEIClientUtils.translate("itempanel.open_usage"));
+            hotkeys.put(
+                    NEIClientUtils.getKeyName(NEIClientUtils.CTRL_HASH, NEIMouseUtils.MOUSE_BTN_LMB),
+                    NEIClientUtils.translate("itempanel.infinite_item"));
         } else {
             hotkeys.put(
                     NEIMouseUtils.getKeyName(NEIMouseUtils.MOUSE_BTN_LMB),

--- a/src/main/resources/assets/nei/lang/en_US.lang
+++ b/src/main/resources/assets/nei/lang/en_US.lang
@@ -64,6 +64,7 @@ nei.itempanel.fill_crafting_grid=Fill Crafting Grid
 nei.itempanel.fill_crafting_grid_quantity=Fill Crafting Grid With Quantity
 nei.itempanel.open_crafting=Recipe to make this item
 nei.itempanel.open_usage=Recipes that use this item
+nei.itempanel.infinite_item=Give Infinite Item
 nei.itempanel.copy_name=Copy Item Name
 nei.itempanel.copy_oredict=Copy Item OreDictionary
 nei.itempanel.copy_id=Copy Item ID


### PR DESCRIPTION
closed: https://github.com/GTNewHorizons/NotEnoughItems/issues/864

<img width="834" height="399" alt="image" src="https://github.com/user-attachments/assets/2b1ddbd2-21f8-464f-b46d-02441eaf8af1" />


(A different modifier was chosen because Shift is already used to open recipes, as in newer versions of JEI)
