### PR TITLE
Fix areStacksSameTypeWithNBT damage check

### DIFF
--- a/src/main/java/codechicken/nei/NEIServerUtils.java
+++ b/src/main/java/codechicken/nei/NEIServerUtils.java
@@ -183,7 +183,7 @@ public class NEIServerUtils {
     public static boolean areStacksSameTypeWithNBT(ItemStack stack1, ItemStack stack2) {
         return stack1 != null && stack2 != null
                 && stack1.getItem() == stack2.getItem()
-                && (!stack2.getHasSubtypes() || stack2.getItemDamage() == stack1.getItemDamage())
+                && (stack2.isItemStackDamageable() || stack2.getItemDamage() == stack1.getItemDamage())
                 && NBTHelper.matchTag(stack1.getTagCompound(), stack2.getTagCompound());
     }
 


### PR DESCRIPTION
Fixed a bug with saving recipes to bookmarks:
<img width="839" height="669" alt="image" src="https://github.com/user-attachments/assets/b27af534-b9f8-4298-84d2-4a5fd12eae3c" />
<img width="604" height="576" alt="image" src="https://github.com/user-attachments/assets/623cda14-8fa0-47a9-ba3b-37f238dcd91b" />
