### PR TITLE
Don't block slot click if canCheatItem is false

### DIFF
--- a/src/main/java/codechicken/nei/NEIController.java
+++ b/src/main/java/codechicken/nei/NEIController.java
@@ -1,6 +1,7 @@
 package codechicken.nei;
 
 import static codechicken.lib.gui.GuiDraw.getMousePosition;
+import static codechicken.nei.NEIClientConfig.canCheatItem;
 
 import java.awt.Point;
 import java.util.LinkedList;
@@ -151,6 +152,8 @@ public class NEIController implements IContainerSlotClickHandler, IContainerInpu
                 && slot != null
                 && slot.getStack() != null
                 && slot.isItemValid(slot.getStack())) {
+            if (!canCheatItem(slot.getStack())) return false;
+
             NEIClientUtils.cheatItem(slot.getStack(), button, 1);
             return true;
         }


### PR DESCRIPTION
In https://github.com/GTNewHorizons/NotEnoughItems/blob/8f949bc1d142b463e3fee7aefbfcd7dc3164c58f/src/main/java/codechicken/nei/guihook/GuiContainerManager.java#L863, NEIController.handleSlotClick is called first, and DefaultSlotClickHandler.handleSlotClick is called last.

NEIController.handleSlotClick returns true regardless of whether cheatItem is possible when the control key is held down. https://github.com/GTNewHorizons/NotEnoughItems/blob/8f949bc1d142b463e3fee7aefbfcd7dc3164c58f/src/main/java/codechicken/nei/NEIController.java#L155

As a result, `eventHandled` in GuiContainerManager.handleMouseClick becomes true, so DefaultSlotClickHandlerhandleSlotClick.handleSlotClick does not call callHandleMouseClick.

I've implemented a special process in the AE2 terminal GUI when a player inventory slot is control-clicked, but this blocks that process.