### PR TITLE
fix client -> server sync in creative gui

### DIFF
--- a/src/main/java/codechicken/nei/NEIClientUtils.java
+++ b/src/main/java/codechicken/nei/NEIClientUtils.java
@@ -32,6 +32,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.PositionedSoundRecord;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.client.gui.inventory.GuiContainerCreative;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.entity.player.EntityPlayer;
@@ -272,8 +273,15 @@ public class NEIClientUtils extends NEIServerUtils {
                     given += qty;
                     if (given >= stack.stackSize) break;
                 }
-                if (given > 0) NEICPH.sendGiveItem(copyStack(typestack, given), false, false);
-            } else NEICPH.sendGiveItem(stack, infinite, true);
+                if (given > 0) {
+                    if (mc().currentScreen instanceof GuiContainerCreative gcc)
+                        gcc.inventorySlots.detectAndSendChanges();
+                    NEICPH.sendGiveItem(copyStack(typestack, given), false, false);
+                }
+            } else {
+                if (mc().currentScreen instanceof GuiContainerCreative gcc) gcc.inventorySlots.detectAndSendChanges();
+                NEICPH.sendGiveItem(stack, infinite, true);
+            }
         } else {
             for (int given = 0; given < stack.stackSize;) {
                 int qty = Math.min(stack.stackSize - given, stack.getMaxStackSize());

--- a/src/main/java/codechicken/nei/NEIClientUtils.java
+++ b/src/main/java/codechicken/nei/NEIClientUtils.java
@@ -274,13 +274,16 @@ public class NEIClientUtils extends NEIServerUtils {
                     if (given >= stack.stackSize) break;
                 }
                 if (given > 0) {
-                    if (mc().currentScreen instanceof GuiContainerCreative gcc)
+                    if (mc().currentScreen instanceof GuiContainerCreative gcc) {
+                        mc().thePlayer.inventory.addItemStackToInventory(stack);
                         gcc.inventorySlots.detectAndSendChanges();
-                    NEICPH.sendGiveItem(copyStack(typestack, given), false, false);
+                    } else NEICPH.sendGiveItem(copyStack(typestack, given), false, false);
                 }
             } else {
-                if (mc().currentScreen instanceof GuiContainerCreative gcc) gcc.inventorySlots.detectAndSendChanges();
-                NEICPH.sendGiveItem(stack, infinite, true);
+                if (mc().currentScreen instanceof GuiContainerCreative gcc) {
+                    mc().thePlayer.inventory.addItemStackToInventory(stack);
+                    gcc.inventorySlots.detectAndSendChanges();
+                } else NEICPH.sendGiveItem(stack, infinite, true);
             }
         } else {
             for (int given = 0; given < stack.stackSize;) {

--- a/src/main/java/codechicken/nei/recipe/CheatItemHandler.java
+++ b/src/main/java/codechicken/nei/recipe/CheatItemHandler.java
@@ -1,6 +1,9 @@
 package codechicken.nei.recipe;
 
+import static com.gtnewhorizon.gtnhlib.ClientProxy.mc;
+
 import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.client.gui.inventory.GuiContainerCreative;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
@@ -30,9 +33,16 @@ public class CheatItemHandler extends INEIGuiAdapter {
                         .min(contents + add, Math.min(overSlot.getSlotStackLimit(), draggedStack.getMaxStackSize()));
 
                 if (total > contents) {
-                    NEIClientUtils
-                            .setSlotContents(overSlot.slotNumber, NEIServerUtils.copyStack(draggedStack, total), true);
-                    NEICPH.sendGiveItem(NEIServerUtils.copyStack(draggedStack, total), false, false);
+                    if (mc.currentScreen instanceof GuiContainerCreative gcc) {
+                        mc.thePlayer.inventory.addItemStackToInventory(draggedStack);
+                        gcc.inventorySlots.detectAndSendChanges();
+                    } else {
+                        NEIClientUtils.setSlotContents(
+                                overSlot.slotNumber,
+                                NEIServerUtils.copyStack(draggedStack, total),
+                                true);
+                        NEICPH.sendGiveItem(NEIServerUtils.copyStack(draggedStack, total), false, false);
+                    }
                     draggedStack.stackSize -= total - contents;
                 }
 


### PR DESCRIPTION
In creative gui minecraft use non standart behavior, it use client instead fo server as base for sync.
Slots sync use two arrays with slots side1 and side2. When side1[n] != side2[n] do sync pocket for that slot.

For example we have empty inventory. both client and server have side1 and side2 empty.
Then we get item from nei. nei send server packet set slot content, server side trigger side1[0] != side2[0] and send update packet to client.
Now we have server side have side1[0] and side2[0] have same items, meanwhile client have side1[0] with item, side2[0] empty.
When we grab item from that slot on client side1[0] became empty. So when creative gui trigger sync method on client side1[0] = side2[0], no changes, no update packet. On client we have empty slot, on server slot with item and both think all synced.
