### PR TITLE
fix by mixin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -107,7 +107,7 @@ apiPackage =
 accessTransformersFile = nei_at.cfg
 
 # Provides setup for Mixins if enabled. If you don't know what mixins are: Keep it disabled!
-usesMixins = false
+usesMixins = true
 
 # Set to a non-empty string to configure mixins in a separate source set under src/VALUE, instead of src/main.
 # This can speed up compile times thanks to not running the mixin annotation processor on all input sources.
@@ -115,7 +115,7 @@ usesMixins = false
 separateMixinSourceSet =
 
 # Adds some debug arguments like verbose output and class export.
-usesMixinDebug = false
+usesMixinDebug = true
 
 # Specify the location of your implementation of IMixinConfigPlugin. Leave it empty otherwise.
 mixinPlugin =
@@ -123,7 +123,7 @@ mixinPlugin =
 # Specify the package that contains all of your Mixins. The package must exist or
 # the build will fail. If you have a package property defined in your mixins.<modid>.json,
 # it must match with this or the build will fail.
-mixinsPackage =
+mixinsPackage = mixins
 
 # Specify the core mod entry class if you use a core mod. This class must implement IFMLLoadingPlugin!
 # This parameter is for legacy compatibility only

--- a/src/main/java/codechicken/nei/NEIClientUtils.java
+++ b/src/main/java/codechicken/nei/NEIClientUtils.java
@@ -32,7 +32,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.PositionedSoundRecord;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.inventory.GuiContainer;
-import net.minecraft.client.gui.inventory.GuiContainerCreative;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.entity.player.EntityPlayer;
@@ -274,16 +273,10 @@ public class NEIClientUtils extends NEIServerUtils {
                     if (given >= stack.stackSize) break;
                 }
                 if (given > 0) {
-                    if (mc().currentScreen instanceof GuiContainerCreative gcc) {
-                        mc().thePlayer.inventory.addItemStackToInventory(stack);
-                        gcc.inventorySlots.detectAndSendChanges();
-                    } else NEICPH.sendGiveItem(copyStack(typestack, given), false, false);
+                    NEICPH.sendGiveItem(copyStack(typestack, given), false, false);
                 }
             } else {
-                if (mc().currentScreen instanceof GuiContainerCreative gcc) {
-                    mc().thePlayer.inventory.addItemStackToInventory(stack);
-                    gcc.inventorySlots.detectAndSendChanges();
-                } else NEICPH.sendGiveItem(stack, infinite, true);
+                NEICPH.sendGiveItem(stack, infinite, true);
             }
         } else {
             for (int given = 0; given < stack.stackSize;) {

--- a/src/main/java/codechicken/nei/mixins/MixinMinecraft_Container.java
+++ b/src/main/java/codechicken/nei/mixins/MixinMinecraft_Container.java
@@ -1,0 +1,20 @@
+package codechicken.nei.mixins;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.inventory.GuiContainerCreative;
+import net.minecraft.inventory.Container;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(Container.class)
+public class MixinMinecraft_Container {
+
+    @Redirect(
+            method = "slotClick",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/inventory/Container;detectAndSendChanges()V"))
+    private void nei$cancelClientToServerSync(Container instance) {
+        if (!(Minecraft.getMinecraft().currentScreen instanceof GuiContainerCreative)) instance.detectAndSendChanges();
+    }
+}

--- a/src/main/java/codechicken/nei/mixins/MixinMinecraft_Container.java
+++ b/src/main/java/codechicken/nei/mixins/MixinMinecraft_Container.java
@@ -11,6 +11,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 @Mixin(Container.class)
 public class MixinMinecraft_Container {
 
+    // Disable client -> server slots sync
     @Redirect(
             method = "slotClick",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/inventory/Container;detectAndSendChanges()V"))

--- a/src/main/java/codechicken/nei/mixins/MixinMinecraft_GuiContainerCreative.java
+++ b/src/main/java/codechicken/nei/mixins/MixinMinecraft_GuiContainerCreative.java
@@ -1,12 +1,12 @@
 package codechicken.nei.mixins;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.inventory.GuiContainerCreative;
 import net.minecraft.client.multiplayer.PlayerControllerMP;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
+import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.play.client.C0EPacketClickWindow;
 
@@ -75,8 +75,9 @@ public class MixinMinecraft_GuiContainerCreative {
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/entity/player/InventoryPlayer;setItemStack(Lnet/minecraft/item/ItemStack;)V"))
-    private void nei$setServerHandItem(InventoryPlayer instance, ItemStack itemStack) {
-        if (itemStack != null && GuiScreen.isShiftKeyDown()) itemStack.stackSize = itemStack.getMaxStackSize();
+    private void nei$setServerHandItem(InventoryPlayer instance, ItemStack itemStack, Slot slotIn, int slotId,
+            int clickedButton, int clickType) {
+        if (itemStack != null && clickType == 1) itemStack.stackSize = itemStack.getMaxStackSize();
         NEIClientUtils.setSlotContents(-999, itemStack, false);
     }
 

--- a/src/main/java/codechicken/nei/mixins/MixinMinecraft_GuiContainerCreative.java
+++ b/src/main/java/codechicken/nei/mixins/MixinMinecraft_GuiContainerCreative.java
@@ -1,0 +1,101 @@
+package codechicken.nei.mixins;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.inventory.GuiContainerCreative;
+import net.minecraft.client.multiplayer.PlayerControllerMP;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.inventory.Container;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import codechicken.nei.NEICPH;
+import codechicken.nei.NEIClientUtils;
+
+@Mixin(GuiContainerCreative.class)
+public class MixinMinecraft_GuiContainerCreative {
+
+    @Mixin(targets = "net.minecraft.client.gui.inventory.GuiContainerCreative$ContainerCreative")
+    public static class MixinMinecraft_GuiContainerCreative_ContainerCreative {
+
+        // Fix double click grab
+        @Inject(method = "func_94530_a", at = @At(value = "TAIL"), cancellable = true)
+        public void nei$doubleClickGrab(ItemStack p_94530_1_, Slot p_94530_2_, CallbackInfoReturnable<Boolean> cir) {
+            Minecraft mc = Minecraft.getMinecraft();
+            if (mc.currentScreen instanceof GuiContainerCreative gcc) {
+                if (gcc.func_147056_g() == CreativeTabs.tabInventory.getTabIndex()) cir.setReturnValue(true);
+            }
+        }
+    }
+
+    // Replace client side click handler with usual click handler
+    @Redirect(
+            method = "handleMouseClick",
+            at = @At(
+                    value = "INVOKE",
+                    ordinal = 0,
+                    target = "Lnet/minecraft/inventory/Container;slotClick(IIILnet/minecraft/entity/player/EntityPlayer;)Lnet/minecraft/item/ItemStack;"))
+    public ItemStack nei$cancelClientSlotClick(Container instance, int slotId, int clickedButton, int clickType,
+            EntityPlayer player) {
+        Minecraft mc = Minecraft.getMinecraft();
+        if (mc.currentScreen instanceof GuiContainerCreative) {
+            mc.playerController.windowClick(instance.windowId, slotId, clickedButton, clickType, player);
+        }
+
+        return null;
+    }
+
+    // Move from creative tabs to hotbar by keyboard number keys
+    @Redirect(
+            method = "handleMouseClick",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/entity/player/InventoryPlayer;setInventorySlotContents(ILnet/minecraft/item/ItemStack;)V"))
+    public void nei$cancelClientSetInventory(InventoryPlayer instance, int index, ItemStack stack) {
+        Minecraft mc = Minecraft.getMinecraft();
+        if (mc.currentScreen instanceof GuiContainerCreative) {
+            mc.playerController.sendSlotPacket(stack, 36 + index);
+        }
+
+        // Because mc not allow sync packet from server for creative tabs gui
+        instance.setInventorySlotContents(index, stack);
+    }
+
+    // Need when you take stack from creative tab and then drag move in inventory tab
+    @Redirect(
+            method = "handleMouseClick",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/entity/player/InventoryPlayer;setItemStack(Lnet/minecraft/item/ItemStack;)V"))
+    public void nei$setServerHandItem(InventoryPlayer instance, ItemStack itemStack) {
+        if (itemStack != null && GuiScreen.isShiftKeyDown()) itemStack.stackSize = itemStack.getMaxStackSize();
+        NEIClientUtils.setSlotContents(-999, itemStack, false);
+    }
+
+    // Empty server hand after stack grabbed from creative tab sent to server
+    @Redirect(
+            method = "handleMouseClick",
+            at = @At(
+                    value = "INVOKE",
+                    ordinal = 2,
+                    target = "Lnet/minecraft/client/multiplayer/PlayerControllerMP;sendSlotPacket(Lnet/minecraft/item/ItemStack;I)V"))
+    public void nei$resetPlayerHandOnServer(PlayerControllerMP instance, ItemStack itemStackIn, int slotId) {
+        instance.sendSlotPacket(itemStackIn, slotId);
+        NEICPH.sendSetSlot(-999, null, false);
+    }
+
+    // Disable client -> server slots sync
+    @Redirect(
+            method = "handleMouseClick",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/inventory/Container;detectAndSendChanges()V"))
+    public void nei$cancelClientToServerSync(Container instance) {}
+
+}

--- a/src/main/java/codechicken/nei/mixins/MixinMinecraft_GuiContainerCreative.java
+++ b/src/main/java/codechicken/nei/mixins/MixinMinecraft_GuiContainerCreative.java
@@ -4,37 +4,20 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.inventory.GuiContainerCreative;
 import net.minecraft.client.multiplayer.PlayerControllerMP;
-import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
-import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
+import net.minecraft.network.play.client.C0EPacketClickWindow;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import codechicken.nei.NEICPH;
 import codechicken.nei.NEIClientUtils;
 
 @Mixin(GuiContainerCreative.class)
 public class MixinMinecraft_GuiContainerCreative {
-
-    @Mixin(targets = "net.minecraft.client.gui.inventory.GuiContainerCreative$ContainerCreative")
-    public static class MixinMinecraft_GuiContainerCreative_ContainerCreative {
-
-        // Fix double click grab
-        @Inject(method = "func_94530_a", at = @At(value = "TAIL"), cancellable = true)
-        public void nei$doubleClickGrab(ItemStack p_94530_1_, Slot p_94530_2_, CallbackInfoReturnable<Boolean> cir) {
-            Minecraft mc = Minecraft.getMinecraft();
-            if (mc.currentScreen instanceof GuiContainerCreative gcc) {
-                if (gcc.func_147056_g() == CreativeTabs.tabInventory.getTabIndex()) cir.setReturnValue(true);
-            }
-        }
-    }
 
     // Replace client side click handler with usual click handler
     @Redirect(
@@ -43,11 +26,31 @@ public class MixinMinecraft_GuiContainerCreative {
                     value = "INVOKE",
                     ordinal = 0,
                     target = "Lnet/minecraft/inventory/Container;slotClick(IIILnet/minecraft/entity/player/EntityPlayer;)Lnet/minecraft/item/ItemStack;"))
-    public ItemStack nei$cancelClientSlotClick(Container instance, int slotId, int clickedButton, int clickType,
+    private ItemStack nei$cancelClientSlotClick(Container instance, int slotId, int clickedButton, int clickType,
+            EntityPlayer player) {
+        return Minecraft.getMinecraft().playerController
+                .windowClick(instance.windowId, slotId, clickedButton, clickType, player);
+    }
+
+    // Creative tabs set slots
+    @Redirect(
+            method = "handleMouseClick",
+            at = @At(
+                    value = "INVOKE",
+                    ordinal = 1,
+                    target = "Lnet/minecraft/inventory/Container;slotClick(IIILnet/minecraft/entity/player/EntityPlayer;)Lnet/minecraft/item/ItemStack;"))
+    private ItemStack nei$forkSlotClick(Container instance, int slotId, int clickedButton, int clickType,
             EntityPlayer player) {
         Minecraft mc = Minecraft.getMinecraft();
-        if (mc.currentScreen instanceof GuiContainerCreative) {
-            mc.playerController.windowClick(instance.windowId, slotId, clickedButton, clickType, player);
+        if (mc.currentScreen instanceof GuiContainerCreative gcc) {
+            // Client side
+            short short1 = player.openContainer.getNextTransactionID(player.inventory);
+            ItemStack itemstack = player.openContainer.slotClick(slotId, clickedButton, clickType, player);
+
+            // Server side
+            slotId = slotId != -999 ? slotId - gcc.inventorySlots.inventorySlots.size() + 9 + 36 : -999;
+            ((MixinMinecraft_PlayerControllerMP) mc.playerController).nei$getNetClientHandler().addToSendQueue(
+                    new C0EPacketClickWindow(instance.windowId, slotId, clickedButton, clickType, itemstack, short1));
         }
 
         return null;
@@ -59,11 +62,8 @@ public class MixinMinecraft_GuiContainerCreative {
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/entity/player/InventoryPlayer;setInventorySlotContents(ILnet/minecraft/item/ItemStack;)V"))
-    public void nei$cancelClientSetInventory(InventoryPlayer instance, int index, ItemStack stack) {
-        Minecraft mc = Minecraft.getMinecraft();
-        if (mc.currentScreen instanceof GuiContainerCreative) {
-            mc.playerController.sendSlotPacket(stack, 36 + index);
-        }
+    private void nei$cancelClientSetInventory(InventoryPlayer instance, int index, ItemStack stack) {
+        Minecraft.getMinecraft().playerController.sendSlotPacket(stack, 36 + index);
 
         // Because mc not allow sync packet from server for creative tabs gui
         instance.setInventorySlotContents(index, stack);
@@ -75,27 +75,23 @@ public class MixinMinecraft_GuiContainerCreative {
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/entity/player/InventoryPlayer;setItemStack(Lnet/minecraft/item/ItemStack;)V"))
-    public void nei$setServerHandItem(InventoryPlayer instance, ItemStack itemStack) {
+    private void nei$setServerHandItem(InventoryPlayer instance, ItemStack itemStack) {
         if (itemStack != null && GuiScreen.isShiftKeyDown()) itemStack.stackSize = itemStack.getMaxStackSize();
         NEIClientUtils.setSlotContents(-999, itemStack, false);
     }
 
-    // Empty server hand after stack grabbed from creative tab sent to server
+    // Use mixin for sync
     @Redirect(
             method = "handleMouseClick",
             at = @At(
                     value = "INVOKE",
                     ordinal = 2,
                     target = "Lnet/minecraft/client/multiplayer/PlayerControllerMP;sendSlotPacket(Lnet/minecraft/item/ItemStack;I)V"))
-    public void nei$resetPlayerHandOnServer(PlayerControllerMP instance, ItemStack itemStackIn, int slotId) {
-        instance.sendSlotPacket(itemStackIn, slotId);
-        NEICPH.sendSetSlot(-999, null, false);
-    }
+    private void nei$cancelClientToServerSetSlot(PlayerControllerMP instance, ItemStack itemStackIn, int slotId) {}
 
     // Disable client -> server slots sync
     @Redirect(
             method = "handleMouseClick",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/inventory/Container;detectAndSendChanges()V"))
-    public void nei$cancelClientToServerSync(Container instance) {}
-
+    private void nei$cancelClientToServerSync(Container instance) {}
 }

--- a/src/main/java/codechicken/nei/mixins/MixinMinecraft_GuiContainerCreative_ContainerCreative.java
+++ b/src/main/java/codechicken/nei/mixins/MixinMinecraft_GuiContainerCreative_ContainerCreative.java
@@ -1,0 +1,25 @@
+package codechicken.nei.mixins;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.inventory.GuiContainerCreative;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(targets = "net.minecraft.client.gui.inventory.GuiContainerCreative$ContainerCreative")
+public class MixinMinecraft_GuiContainerCreative_ContainerCreative {
+
+    // Fix double click grab
+    @Inject(method = "func_94530_a", at = @At(value = "TAIL"), cancellable = true)
+    private void nei$doubleClickGrab(ItemStack p_94530_1_, Slot p_94530_2_, CallbackInfoReturnable<Boolean> cir) {
+        Minecraft mc = Minecraft.getMinecraft();
+        if (mc.currentScreen instanceof GuiContainerCreative gcc) {
+            if (gcc.func_147056_g() == CreativeTabs.tabInventory.getTabIndex()) cir.setReturnValue(true);
+        }
+    }
+}

--- a/src/main/java/codechicken/nei/mixins/MixinMinecraft_PlayerControllerMP.java
+++ b/src/main/java/codechicken/nei/mixins/MixinMinecraft_PlayerControllerMP.java
@@ -1,0 +1,15 @@
+package codechicken.nei.mixins;
+
+import net.minecraft.client.multiplayer.PlayerControllerMP;
+import net.minecraft.client.network.NetHandlerPlayClient;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(PlayerControllerMP.class)
+public interface MixinMinecraft_PlayerControllerMP {
+
+    @Accessor("netClientHandler")
+    NetHandlerPlayClient nei$getNetClientHandler();
+
+}

--- a/src/main/java/codechicken/nei/recipe/CheatItemHandler.java
+++ b/src/main/java/codechicken/nei/recipe/CheatItemHandler.java
@@ -33,16 +33,10 @@ public class CheatItemHandler extends INEIGuiAdapter {
                         .min(contents + add, Math.min(overSlot.getSlotStackLimit(), draggedStack.getMaxStackSize()));
 
                 if (total > contents) {
-                    if (mc.currentScreen instanceof GuiContainerCreative gcc) {
-                        mc.thePlayer.inventory.addItemStackToInventory(draggedStack);
-                        gcc.inventorySlots.detectAndSendChanges();
-                    } else {
-                        NEIClientUtils.setSlotContents(
-                                overSlot.slotNumber,
-                                NEIServerUtils.copyStack(draggedStack, total),
-                                true);
-                        NEICPH.sendGiveItem(NEIServerUtils.copyStack(draggedStack, total), false, false);
-                    }
+                    final int slotNumber = mc.currentScreen instanceof GuiContainerCreative ? overSlot.getSlotIndex()
+                            : overSlot.slotNumber;
+                    NEIClientUtils.setSlotContents(slotNumber, NEIServerUtils.copyStack(draggedStack, total), true);
+                    NEICPH.sendGiveItem(NEIServerUtils.copyStack(draggedStack, total), false, false);
                     draggedStack.stackSize -= total - contents;
                 }
 

--- a/src/main/resources/mixins.NotEnoughItems.json
+++ b/src/main/resources/mixins.NotEnoughItems.json
@@ -2,12 +2,16 @@
   "required": true,
   "minVersion": "0.8.5-GTNH",
   "package": "codechicken.nei.mixins",
-  "refmap": "mixins.mymodid.refmap.json",
+  "refmap": "mixins.NotEnoughItems.refmap.json",
   "target": "@env(DEFAULT)",
   "compatibilityLevel": "JAVA_8",
   "client": [
     "MixinMinecraft_GuiContainerCreative",
-    "MixinMinecraft_GuiContainerCreative$MixinMinecraft_GuiContainerCreative_ContainerCreative"
+    "MixinMinecraft_GuiContainerCreative_ContainerCreative",
+    "MixinMinecraft_PlayerControllerMP"
   ],
-  "server": []
+  "server": [],
+  "mixins": [
+    "MixinMinecraft_Container"
+  ]
 }

--- a/src/main/resources/mixins.NotEnoughItems.json
+++ b/src/main/resources/mixins.NotEnoughItems.json
@@ -1,0 +1,13 @@
+{
+  "required": true,
+  "minVersion": "0.8.5-GTNH",
+  "package": "codechicken.nei.mixins",
+  "refmap": "mixins.mymodid.refmap.json",
+  "target": "@env(DEFAULT)",
+  "compatibilityLevel": "JAVA_8",
+  "client": [
+    "MixinMinecraft_GuiContainerCreative",
+    "MixinMinecraft_GuiContainerCreative$MixinMinecraft_GuiContainerCreative_ContainerCreative"
+  ],
+  "server": []
+}

--- a/src/main/resources/mixins.NotEnoughItems.json
+++ b/src/main/resources/mixins.NotEnoughItems.json
@@ -8,10 +8,9 @@
   "client": [
     "MixinMinecraft_GuiContainerCreative",
     "MixinMinecraft_GuiContainerCreative_ContainerCreative",
-    "MixinMinecraft_PlayerControllerMP"
+    "MixinMinecraft_PlayerControllerMP",
+    "MixinMinecraft_Container"
   ],
   "server": [],
-  "mixins": [
-    "MixinMinecraft_Container"
-  ]
+  "mixins": []
 }


### PR DESCRIPTION
Same as https://github.com/GTNewHorizons/NotEnoughItems/pull/913

This allow double click grab in creative gui inventory

FIXED ~~Known issue (not new):
if you grab stack from creative tab then drag move on few horbar slots and then double click grab, thing get desync. Because server and client have different number and index of slots, playerController.windowClick() method doesnt work, need custom method in mixin, but palyerController.netClientHandler is private so i see no way.~~