### PR TITLE
Prevent ConcurrentModificationException while searching for fuels in ItemList

### DIFF
--- a/src/main/java/codechicken/nei/ItemList.java
+++ b/src/main/java/codechicken/nei/ItemList.java
@@ -251,7 +251,6 @@ public class ItemList {
 
         private void updateOrdering(List<ItemStack> items) {
             final Map<ItemStack, Integer> newOrdering = new HashMap<>();
-            ItemSorter.sort(items);
 
             if (!CollapsibleItems.isEmpty()) {
                 final HashMap<Integer, Integer> groups = new HashMap<>();
@@ -423,6 +422,9 @@ public class ItemList {
                     ItemSorter.instance.ordering.put(stack, index++);
                 }
             }
+
+            if (interrupted()) return;
+            ItemSorter.sort(items);
 
             if (interrupted()) return;
             ItemList.items = items;

--- a/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
@@ -84,12 +84,13 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
         efuels.add(Item.getItemFromBlock(Blocks.wooden_door));
         efuels.add(Item.getItemFromBlock(Blocks.trapped_chest));
 
-        Stopwatch stopwatch = Stopwatch.createStarted();
+        final Stopwatch stopwatch = Stopwatch.createStarted();
+        final List<ItemStack> itemsSnapshot = new ArrayList<>(ItemList.items);
         if (parallel) {
             try {
                 FurnaceRecipeHandler.afuels = ItemList.forkJoinPool
                         .submit(
-                                () -> ItemList.items.parallelStream().map(TemplateRecipeHandler::identifyFuel)
+                                () -> itemsSnapshot.parallelStream().map(TemplateRecipeHandler::identifyFuel)
                                         .filter(Objects::nonNull).collect(Collectors.toCollection(ArrayList::new)))
                         .get();
             } catch (InterruptedException | ExecutionException e) {
@@ -97,7 +98,7 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
                 e.printStackTrace();
             }
         } else {
-            FurnaceRecipeHandler.afuels = ItemList.items.stream().map(TemplateRecipeHandler::identifyFuel)
+            FurnaceRecipeHandler.afuels = itemsSnapshot.stream().map(TemplateRecipeHandler::identifyFuel)
                     .filter(Objects::nonNull).collect(Collectors.toCollection(ArrayList::new));
         }
 


### PR DESCRIPTION
error:

```
java.util.ConcurrentModificationException
at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1722)
at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)
at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:723)
at codechicken.nei.recipe.TemplateRecipeHandler.findFuels(TemplateRecipeHandler.java:101)
at codechicken.nei.recipe.TemplateRecipeHandler.findFuelsOnce(TemplateRecipeHandler.java:59)
at codechicken.nei.recipe.RecipeHandlerQuery.getRecipeHandlersParallel(RecipeHandlerQuery.java:69)
at codechicken.nei.recipe.RecipeHandlerQuery.runWithProfiling(RecipeHandlerQuery.java:48)
at codechicken.nei.recipe.GuiCraftingRecipe.getCraftingHandlers(GuiCraftingRecipe.java:98)
at codechicken.nei.recipe.GuiCraftingRecipe.createRecipeGui(GuiCraftingRecipe.java:53)
at codechicken.nei.recipe.GuiCraftingRecipe.openRecipeGui(GuiCraftingRecipe.java:32)
at codechicken.nei.api.ShortcutInputHandler.handleKeyEvent(ShortcutInputHandler.java:140)
at codechicken.nei.recipe.RecipeItemInputHandler.lastKeyTyped(RecipeItemInputHandler.java:36)
at codechicken.nei.guihook.GuiContainerManager.lastKeyTyped(GuiContainerManager.java:499)
at net.minecraft.client.gui.inventory.GuiContainer.keyTyped(GuiContainer.java)
at net.minecraft.client.gui.inventory.GuiContainerCreative.keyTyped(GuiContainerCreative.java:301)
at net.minecraft.client.gui.inventory.GuiContainer.public_func_73869_a(GuiContainer.java)
at codechicken.nei.guihook.GuiContainerManager.callKeyTyped(GuiContainerManager.java)
at codechicken.nei.guihook.GuiContainerManager.keyTyped(GuiContainerManager.java:885)
at codechicken.nei.guihook.GuiContainerManager.handleKeyboardInput(GuiContainerManager.java:872)
at net.minecraft.client.gui.inventory.GuiContainer.handleKeyboardInput(GuiContainer.java)
at net.minecraft.client.gui.GuiScreen.redirect$bpe000$modularui2$modularui$injectKeyboardInputEvent(GuiScreen.java:3560)
at net.minecraft.client.gui.GuiScreen.handleInput(GuiScreen.java:276)
at net.minecraft.client.Minecraft.runTick(Minecraft.java:1640)
at net.minecraft.client.Minecraft.runGameLoop(Minecraft.java:973)
at net.minecraft.client.Minecraft.run(Minecraft.java:7610)
at net.minecraft.client.main.Main.main(SourceFile:148)
at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
at java.lang.reflect.Method.invoke(Method.java:565)
at net.minecraft.launchwrapper.Launch.rfb$realLaunch(Launch.java:250)
at net.minecraft.launchwrapper.Launch.launch(Launch.java:35)
at net.minecraft.launchwrapper.Launch.main(Launch.java:60)
at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
at java.lang.reflect.Method.invoke(Method.java:565)
at com.gtnewhorizons.retrofuturabootstrap.Main.main(Main.java:207)
at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:115)
at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129)
at org.prismlauncher.EntryPoint.main(EntryPoint.java:70)
```