### PR TITLE
Expose PositionedStack to IRecipeHandler.handleItemTooltip implementations

### DIFF
--- a/src/main/java/codechicken/nei/api/API.java
+++ b/src/main/java/codechicken/nei/api/API.java
@@ -11,6 +11,7 @@ import net.minecraft.inventory.Slot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
+import org.jetbrains.annotations.Nullable;
 import org.lwjgl.input.Keyboard;
 
 import com.google.common.collect.Sets;
@@ -24,6 +25,7 @@ import codechicken.nei.KeyManager.KeyState;
 import codechicken.nei.LayoutManager;
 import codechicken.nei.NEIClientConfig;
 import codechicken.nei.OffsetPositioner;
+import codechicken.nei.PositionedStack;
 import codechicken.nei.SearchField;
 import codechicken.nei.SearchField.ISearchProvider;
 import codechicken.nei.SearchTokenParser.ISearchParserProvider;
@@ -442,4 +444,50 @@ public class API {
 
     @Deprecated
     public static void addRecipeCatalyst(List<ItemStack> stacks, Class<? extends IRecipeHandler> handler) {}
+
+    private static boolean inHandleItemTooltip;
+    private static PositionedStack itemTooltipHoveredStack;
+    private static int itemTooltipMouseX, itemTooltipMouseY;
+
+    public static void beginHandleItemTooltip(PositionedStack stack, int mouseX, int mouseY) {
+        inHandleItemTooltip = true;
+        itemTooltipHoveredStack = stack;
+        itemTooltipMouseX = mouseX;
+        itemTooltipMouseY = mouseY;
+    }
+
+    public static void endHandleItemTooltip() {
+        inHandleItemTooltip = false;
+        itemTooltipHoveredStack = null;
+        itemTooltipMouseX = 0;
+        itemTooltipMouseY = 0;
+    }
+
+    /// Gets the stack that is currently being hovered over. This can only be called within
+    /// [IRecipeHandler#handleItemTooltip(GuiRecipe, PositionedStack, List, int)].
+    @Nullable
+    public static PositionedStack getItemTooltipHoveredStack() {
+        if (!inHandleItemTooltip) throw new IllegalStateException(
+                "Cannot call getItemTooltipHoveredStack outside of IRecipeHandler.handleItemTooltip");
+
+        return itemTooltipHoveredStack;
+    }
+
+    /// Gets the screen-space mouse X coordinate. This can only be called within
+    /// [IRecipeHandler#handleItemTooltip(GuiRecipe, PositionedStack, List, int)].
+    public static int getItemTooltipMouseX() {
+        if (!inHandleItemTooltip) throw new IllegalStateException(
+                "Cannot call getItemTooltipMouseX outside of IRecipeHandler.handleItemTooltip");
+
+        return itemTooltipMouseX;
+    }
+
+    /// Gets the screen-space mouse Y coordinate. This can only be called within
+    /// [IRecipeHandler#handleItemTooltip(GuiRecipe, PositionedStack, List, int)].
+    public static int getItemTooltipMouseY() {
+        if (!inHandleItemTooltip) throw new IllegalStateException(
+                "Cannot call getItemTooltipMouseY outside of IRecipeHandler.handleItemTooltip");
+
+        return itemTooltipMouseY;
+    }
 }

--- a/src/main/java/codechicken/nei/recipe/NEIRecipeWidget.java
+++ b/src/main/java/codechicken/nei/recipe/NEIRecipeWidget.java
@@ -28,6 +28,7 @@ import codechicken.nei.NEIClientUtils;
 import codechicken.nei.NEIServerUtils;
 import codechicken.nei.PositionedStack;
 import codechicken.nei.Widget;
+import codechicken.nei.api.API;
 import codechicken.nei.api.IGuiContainerOverlay;
 import codechicken.nei.api.ShortcutInputHandler;
 import codechicken.nei.guihook.GuiContainerManager;
@@ -403,11 +404,18 @@ public class NEIRecipeWidget extends Widget {
             return tooltip;
         }
 
-        tooltip = this.handlerRef.handler.handleItemTooltip(guiRecipe, itemstack, tooltip, this.handlerRef.recipeIndex);
+        final PositionedStack hovered = getPositionedStackMouseOver(mousex, mousey);
+
+        try {
+            API.beginHandleItemTooltip(hovered, mousex, mousey);
+
+            tooltip = this.handlerRef.handler
+                    .handleItemTooltip(guiRecipe, itemstack, tooltip, this.handlerRef.recipeIndex);
+        } finally {
+            API.endHandleItemTooltip();
+        }
 
         if (itemstack != null) {
-            final PositionedStack hovered = getPositionedStackMouseOver(mousex, mousey);
-
             if (hovered != null && this.handlerInfo.getShowBadge()) {
                 final List<Badge> badges = getBadges(hovered, getOutputs().indexOf(hovered) == -1);
 


### PR DESCRIPTION
This fixes an issue with `RecipeMapFrontend.handleNEIItemInputTooltip` not being called. I know this solution is ugly (global state) but I can't do much better without changing the signature of `IRecipeHandler.handleItemTooltip`.

Currently, GT5u's recipe handler iterates over all stacks in the recipe and checks if the reference of each ItemStack is the same. If one matches, it draws its tooltip. This is obviously extremely fragile, so I've removed that check entirely and replaced it with a proper way to get the `PositionedStack`. From what I can tell, there's no way to get the mouse position from within `handleItemTooltip` either, so I exposed all three values.

It seems like this problem was caused by ChromaticTooltips, but I decided to get rid of this code entirely and fix it properly, instead of removing the stack copies in ChromaticTooltips.

This is the code that broke: https://github.com/GTNewHorizons/GT5-Unofficial/blob/master/src/main/java/gregtech/api/recipe/RecipeMapFrontend.java#L284-L299
