### PR TITLE
Fix ItemStack load from NBT with short overflow

### DIFF
--- a/src/main/java/codechicken/nei/recipe/stackinfo/DefaultStackStringifyHandler.java
+++ b/src/main/java/codechicken/nei/recipe/stackinfo/DefaultStackStringifyHandler.java
@@ -22,7 +22,7 @@ public class DefaultStackStringifyHandler implements IStackStringifyHandler {
         final NBTTagCompound nbTag = new NBTTagCompound();
         nbTag.setString("strId", strId);
         nbTag.setInteger("Count", saveStackSize ? stack.stackSize : 1);
-        nbTag.setShort("Damage", (short) stack.getItemDamage());
+        nbTag.setInteger("Damage", stack.getItemDamage());
 
         if (stack.hasTagCompound() && !stack.getTagCompound().hasNoTags()) {
             nbTag.setTag("tag", stack.getTagCompound().copy());
@@ -35,7 +35,7 @@ public class DefaultStackStringifyHandler implements IStackStringifyHandler {
         final String strId = nbtTag.getString("strId");
 
         nbtTag = (NBTTagCompound) nbtTag.copy();
-        nbtTag.setShort("id", (short) GameData.getItemRegistry().getId(strId)); // getObject
+        nbtTag.setInteger("id", GameData.getItemRegistry().getId(strId)); // getObject
 
         final ItemStack stack = ItemStack.loadItemStackFromNBT(nbtTag);
 


### PR DESCRIPTION
In some modpacks the item identifier may exceed the short: [issue.txt](https://github.com/user-attachments/files/28287920/error.txt)

```
java.lang.NullPointerException: Updating screen events
	at codechicken.nei.NEIClientUtils.giveStack(NEIClientUtils.java:235)
	at codechicken.nei.NEIClientUtils.cheatItem(NEIClientUtils.java:229)
	at codechicken.nei.PanelWidget.mouseUp(PanelWidget.java:291)
	at codechicken.nei.LayoutManager.onMouseUp(LayoutManager.java:250)
	at codechicken.nei.guihook.GuiContainerManager.mouseUp(GuiContainerManager.java:555)
	at codechicken.nei.guihook.GuiContainerManager.overrideMouseUp(GuiContainerManager.java:548)
	at net.minecraft.client.gui.inventory.GuiContainer.func_146286_b(GuiContainer.java)
	at net.minecraft.client.gui.inventory.GuiContainerCreative.func_146286_b(GuiContainerCreative.java:462)
	at net.minecraft.client.gui.GuiScreen.func_146274_d(GuiScreen.java:306)
	at net.minecraft.client.gui.inventory.GuiContainer.func_146274_d(GuiContainer.java)
	at net.minecraft.client.gui.inventory.GuiContainerCreative.func_146274_d(GuiContainerCreative.java:566)
	at net.minecraft.client.gui.GuiScreen.redirect$bpj000$modularui2$modularui
```