### PR TITLE
Guard loadTransferRects against plugin init errors

### DIFF
--- a/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
@@ -381,8 +381,13 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
     public LinkedList<RecipeTransferRect> transferRects = new LinkedList<>();
 
     public TemplateRecipeHandler() {
-        loadTransferRects();
-        RecipeTransferRectHandler.registerRectsToGuis(getRecipeTransferRectGuis(), transferRects);
+        try {
+            loadTransferRects();
+            RecipeTransferRectHandler.registerRectsToGuis(getRecipeTransferRectGuis(), transferRects);
+        } catch (Exception e) {
+            NEIClientConfig.logger
+                    .error("NEI: Failed to load transfer rects for {}: {}", getClass().getName(), e.toString());
+        }
     }
 
     /**


### PR DESCRIPTION
closed: https://github.com/GTNewHorizons/NotEnoughItems/issues/934