### PR TITLE
Add Cubic Chunks cube overlay & fix chunk grid above y=256, below y=0.

### DIFF
--- a/src/main/java/codechicken/nei/NEIModContainer.java
+++ b/src/main/java/codechicken/nei/NEIModContainer.java
@@ -43,6 +43,7 @@ public class NEIModContainer extends DummyModContainer {
 
     private static boolean gregTech5Loaded;
     private static boolean gtnhLibLoaded;
+    private static boolean cubicChunksLoaded;
 
     private static ASMDataTable asmDataTable;
 
@@ -67,6 +68,10 @@ public class NEIModContainer extends DummyModContainer {
 
     public static boolean isGTNHLibLoaded() {
         return gtnhLibLoaded;
+    }
+
+    public static boolean isCCLoaded() {
+        return cubicChunksLoaded;
     }
 
     @Override
@@ -96,6 +101,7 @@ public class NEIModContainer extends DummyModContainer {
     public void preInit(FMLPreInitializationEvent event) {
         gregTech5Loaded = Loader.isModLoaded("gregtech") && !Loader.isModLoaded("gregapi_post");
         gtnhLibLoaded = Loader.isModLoaded("gtnhlib");
+        cubicChunksLoaded = Loader.isModLoaded("cubicchunks");
         if (CommonUtils.isClient()) ClientHandler.preInit();
         asmDataTable = event.getAsmData();
     }

--- a/src/main/java/codechicken/nei/WorldOverlayRenderer.java
+++ b/src/main/java/codechicken/nei/WorldOverlayRenderer.java
@@ -1,5 +1,7 @@
 package codechicken.nei;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.concurrent.Callable;
@@ -231,6 +233,9 @@ public class WorldOverlayRenderer implements IKeyStateTracker {
     private static void renderChunkBounds(Entity entity, int intOffsetX, int intOffsetY, int intOffsetZ) {
         if (chunkOverlay == 0) return;
 
+        int worldMinY = worldMinHeight(entity.worldObj);
+        int worldMaxY = worldMaxHeight(entity.worldObj);
+
         GL11.glDisable(GL11.GL_TEXTURE_2D);
         GL11.glEnable(GL11.GL_BLEND);
         GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
@@ -249,14 +254,13 @@ public class WorldOverlayRenderer implements IKeyStateTracker {
             double dy = 128;
             double y1 = Math.floor(entity.posY - dy / 2);
             double y2 = y1 + dy;
-            if (y1 < 0) {
-                y1 = 0;
-                y2 = dy;
+            if (y1 < worldMinY) {
+                y1 = worldMinY;
+                y2 = worldMinY + dy;
             }
-
-            if (y1 > entity.worldObj.getHeight()) {
-                y2 = entity.worldObj.getHeight();
-                y1 = y2 - dy;
+            if (y2 > worldMaxY) {
+                y2 = worldMaxY;
+                y1 = Math.max(worldMaxY - dy, worldMinY);
             }
 
             y1 -= intOffsetY;
@@ -282,19 +286,34 @@ public class WorldOverlayRenderer implements IKeyStateTracker {
                 tess.addVertex(x1, y2, z1);
             }
 
+            if (NEIModContainer.isCCLoaded()) {
+                tess.setColorRGBA_F(0, 0.5F, 0.9F, (float) dist * 0.5F);
+                int cubeBase = (int) Math.floor((y1 + intOffsetY) / 16.0) * 16;
+                for (int cubeY = cubeBase; cubeY <= y2 + intOffsetY; cubeY += 16) {
+                    double ry = cubeY - intOffsetY;
+                    tess.addVertex(x1, ry, z1);
+                    tess.addVertex(x2, ry, z1);
+                    tess.addVertex(x1, ry, z2);
+                    tess.addVertex(x2, ry, z2);
+                    tess.addVertex(x1, ry, z1);
+                    tess.addVertex(x1, ry, z2);
+                    tess.addVertex(x2, ry, z1);
+                    tess.addVertex(x2, ry, z2);
+                }
+            }
+
             if (cx == 0 && cz == 0) {
                 if (chunkOverlay == 2) {
                     dy = 32;
                     y1 = Math.floor(entity.posY - dy / 2);
                     y2 = y1 + dy;
-                    if (y1 < 0) {
-                        y1 = 0;
-                        y2 = dy;
+                    if (y1 < worldMinY) {
+                        y1 = worldMinY;
+                        y2 = worldMinY + dy;
                     }
-
-                    if (y1 > entity.worldObj.getHeight()) {
-                        y2 = entity.worldObj.getHeight();
-                        y1 = y2 - dy;
+                    if (y2 > worldMaxY) {
+                        y2 = worldMaxY;
+                        y1 = Math.max(worldMaxY - dy, worldMinY);
                     }
 
                     y1 -= intOffsetY;
@@ -391,6 +410,42 @@ public class WorldOverlayRenderer implements IKeyStateTracker {
         GL11.glEnable(GL11.GL_LIGHTING);
         GL11.glEnable(GL11.GL_TEXTURE_2D);
         GL11.glDisable(GL11.GL_BLEND);
+    }
+
+    /** Holder defers class loading until Cubic Chunks is confirmed present. */
+    private static final class CCWorldBounds {
+
+        static final MethodHandle GET_MIN_HEIGHT;
+        static final MethodHandle GET_MAX_HEIGHT;
+
+        static {
+            try {
+                MethodHandles.Lookup lookup = MethodHandles.lookup();
+                // Mixined into World by CC, use reflection + MethodHandles to call these
+                GET_MIN_HEIGHT = lookup.unreflect(World.class.getMethod("getMinHeight"));
+                GET_MAX_HEIGHT = lookup.unreflect(World.class.getMethod("getMaxHeight"));
+            } catch (ReflectiveOperationException e) {
+                throw new ExceptionInInitializerError(e);
+            }
+        }
+    }
+
+    private static int worldMinHeight(World world) {
+        if (!NEIModContainer.isCCLoaded()) return 0;
+        try {
+            return (int) CCWorldBounds.GET_MIN_HEIGHT.invoke(world);
+        } catch (Throwable ignored) {
+            return 0;
+        }
+    }
+
+    private static int worldMaxHeight(World world) {
+        if (!NEIModContainer.isCCLoaded()) return world.getHeight();
+        try {
+            return (int) CCWorldBounds.GET_MAX_HEIGHT.invoke(world);
+        } catch (Throwable ignored) {
+            return world.getHeight();
+        }
     }
 
     private static Callable<String> oregenPatternReader;


### PR DESCRIPTION
## Summary
NEI's chunk overlay currently clamps its height to inside of the world. This PR redirects that logic to use CC's getMinHeight and getMaxHeight methods, which are mixined into World when CC is loaded.
This also adds blue/cyan lines to demarcate cube boundaries.
There is no change if CC is not present, everything behaves exactly the same.

<img width="1920" height="1025" alt="2026-07-08_16 51 00" src="https://github.com/user-attachments/assets/8d021041-da7d-4783-9bd3-d3916da498c8" />

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
