### PR TITLE
Allow proper representation of recipes with multiple results

### DIFF
--- a/src/main/java/codechicken/nei/FavoriteRecipes.java
+++ b/src/main/java/codechicken/nei/FavoriteRecipes.java
@@ -129,7 +129,7 @@ public class FavoriteRecipes {
 
         protected List<PositionedStack> getOutputs(IRecipeHandler handler, int recipeIndex) {
             final List<PositionedStack> pStackResults = handler.getResultStacks(recipeIndex);
-            return pStackResults != null ? pStackResults : handler.getOtherStacks(recipeIndex);
+            return pStackResults.isEmpty() ? pStackResults : handler.getOtherStacks(recipeIndex);
         }
 
     };

--- a/src/main/java/codechicken/nei/FavoriteRecipes.java
+++ b/src/main/java/codechicken/nei/FavoriteRecipes.java
@@ -129,7 +129,7 @@ public class FavoriteRecipes {
 
         protected List<PositionedStack> getOutputs(IRecipeHandler handler, int recipeIndex) {
             final List<PositionedStack> pStackResults = handler.getResultStacks(recipeIndex);
-            return pStackResults.isEmpty() ? pStackResults : handler.getOtherStacks(recipeIndex);
+            return !pStackResults.isEmpty() ? pStackResults : handler.getOtherStacks(recipeIndex);
         }
 
     };

--- a/src/main/java/codechicken/nei/FavoriteRecipes.java
+++ b/src/main/java/codechicken/nei/FavoriteRecipes.java
@@ -8,7 +8,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -129,8 +128,8 @@ public class FavoriteRecipes {
         }
 
         protected List<PositionedStack> getOutputs(IRecipeHandler handler, int recipeIndex) {
-            final PositionedStack pStackResult = handler.getResultStack(recipeIndex);
-            return pStackResult != null ? Collections.singletonList(pStackResult) : handler.getOtherStacks(recipeIndex);
+            final List<PositionedStack> pStackResults = handler.getResultStacks(recipeIndex);
+            return pStackResults != null ? pStackResults : handler.getOtherStacks(recipeIndex);
         }
 
     };

--- a/src/main/java/codechicken/nei/PresetsList.java
+++ b/src/main/java/codechicken/nei/PresetsList.java
@@ -101,7 +101,7 @@ public class PresetsList {
                 return true;
             }
 
-            final List<PositionedStack> extraInputs = handler.getExtraInputStacks(recipeIndex);
+            final List<PositionedStack> extraInputs = handler.getCatalystStacks(recipeIndex);
 
             if (!extraInputs.isEmpty() && matchPositionedStack(extraInputs, true)) {
                 return true;

--- a/src/main/java/codechicken/nei/PresetsList.java
+++ b/src/main/java/codechicken/nei/PresetsList.java
@@ -101,6 +101,12 @@ public class PresetsList {
                 return true;
             }
 
+            final List<PositionedStack> extraInputs = handler.getExtraInputStacks(recipeIndex);
+
+            if (!extraInputs.isEmpty() && matchPositionedStack(extraInputs, true)) {
+                return true;
+            }
+
             return results.isEmpty() && others.isEmpty();
         }
 

--- a/src/main/java/codechicken/nei/PresetsList.java
+++ b/src/main/java/codechicken/nei/PresetsList.java
@@ -89,9 +89,9 @@ public class PresetsList {
                 return false;
             }
 
-            final PositionedStack result = handler.getResultStack(recipeIndex);
+            final List<PositionedStack> results = handler.getResultStacks(recipeIndex);
 
-            if (result != null && matchPositionedStack(result)) {
+            if (!results.isEmpty() && matchPositionedStack(results, true)) {
                 return true;
             }
 
@@ -101,7 +101,7 @@ public class PresetsList {
                 return true;
             }
 
-            return result == null && others.isEmpty();
+            return results.isEmpty() && others.isEmpty();
         }
 
         private boolean matchPositionedStack(List<PositionedStack> items, boolean dir) {

--- a/src/main/java/codechicken/nei/filter/AllOthersRecipeFilter.java
+++ b/src/main/java/codechicken/nei/filter/AllOthersRecipeFilter.java
@@ -24,6 +24,12 @@ public class AllOthersRecipeFilter implements IRecipeFilter {
             }
         }
 
+        for (PositionedStack pStack : handler.getExtraInputStacks(recipeIndex)) {
+            if (!match(pStack)) {
+                return false;
+            }
+        }
+
         return true;
     }
 

--- a/src/main/java/codechicken/nei/filter/AllOthersRecipeFilter.java
+++ b/src/main/java/codechicken/nei/filter/AllOthersRecipeFilter.java
@@ -24,7 +24,7 @@ public class AllOthersRecipeFilter implements IRecipeFilter {
             }
         }
 
-        for (PositionedStack pStack : handler.getExtraInputStacks(recipeIndex)) {
+        for (PositionedStack pStack : handler.getCatalystStacks(recipeIndex)) {
             if (!match(pStack)) {
                 return false;
             }

--- a/src/main/java/codechicken/nei/filter/AnyOthersRecipeFilter.java
+++ b/src/main/java/codechicken/nei/filter/AnyOthersRecipeFilter.java
@@ -24,7 +24,7 @@ public class AnyOthersRecipeFilter implements IRecipeFilter {
             }
         }
 
-        for (PositionedStack pStack : handler.getExtraInputStacks(recipeIndex)) {
+        for (PositionedStack pStack : handler.getCatalystStacks(recipeIndex)) {
             if (match(pStack)) {
                 return true;
             }

--- a/src/main/java/codechicken/nei/filter/AnyOthersRecipeFilter.java
+++ b/src/main/java/codechicken/nei/filter/AnyOthersRecipeFilter.java
@@ -24,6 +24,12 @@ public class AnyOthersRecipeFilter implements IRecipeFilter {
             }
         }
 
+        for (PositionedStack pStack : handler.getExtraInputStacks(recipeIndex)) {
+            if (match(pStack)) {
+                return true;
+            }
+        }
+
         return false;
     }
 

--- a/src/main/java/codechicken/nei/filter/RecipeFilter.java
+++ b/src/main/java/codechicken/nei/filter/RecipeFilter.java
@@ -48,9 +48,7 @@ public class RecipeFilter implements IRecipeFilter {
         }
 
         if (this.context == FilterContext.ANY || this.context == FilterContext.OUTPUT) {
-            final PositionedStack result = handler.getResultStack(recipeIndex);
-
-            if (result != null && matchPositionedStack(result) == this.anyMatch) {
+            if (matchPositionedStack(handler.getResultStacks(recipeIndex), this.anyMatch)) {
                 return this.anyMatch;
             }
 

--- a/src/main/java/codechicken/nei/filter/RecipeFilter.java
+++ b/src/main/java/codechicken/nei/filter/RecipeFilter.java
@@ -56,7 +56,7 @@ public class RecipeFilter implements IRecipeFilter {
                 return this.anyMatch;
             }
 
-            if (matchPositionedStack(handler.getExtraInputStacks(recipeIndex), this.anyMatch)) {
+            if (matchPositionedStack(handler.getCatalystStacks(recipeIndex), this.anyMatch)) {
                 return this.anyMatch;
             }
 

--- a/src/main/java/codechicken/nei/filter/RecipeFilter.java
+++ b/src/main/java/codechicken/nei/filter/RecipeFilter.java
@@ -56,6 +56,10 @@ public class RecipeFilter implements IRecipeFilter {
                 return this.anyMatch;
             }
 
+            if (matchPositionedStack(handler.getExtraInputStacks(recipeIndex), this.anyMatch)) {
+                return this.anyMatch;
+            }
+
         }
 
         return !this.anyMatch;

--- a/src/main/java/codechicken/nei/recipe/FuelRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/FuelRecipeHandler.java
@@ -38,6 +38,11 @@ public class FuelRecipeHandler extends FurnaceRecipeHandler {
         public PositionedStack getOtherStack() {
             return fuel.stack;
         }
+
+        @Override
+        public PositionedStack getCatalyst() {
+            return fuel.stack;
+        }
     }
 
     private final ArrayList<SmeltingPair> mfurnace = new ArrayList<>();

--- a/src/main/java/codechicken/nei/recipe/IRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/IRecipeHandler.java
@@ -83,12 +83,12 @@ public interface IRecipeHandler {
      * @return A list of the other {@link PositionedStack}s in this recipe relative to the top left corner of your
      *         recipe drawing space. For example fuel in furnaces.
      */
-    default List<PositionedStack> getExtraInputStacks(int recipe) {
+    default List<PositionedStack> getCatalystStacks(int recipe) {
         return Collections.emptyList();
     }
 
     /**
-     * Legacy API, define either {@link #getExtraInputStacks(int)} or {@link #getResultStacks(int)}
+     * Legacy API, define either {@link #getCatalystStacks(int)} or {@link #getResultStacks(int)}
      *
      * @param recipe The recipe index to get items for.
      * @return A list of the other {@link PositionedStack}s in this recipe relative to the top left corner of your

--- a/src/main/java/codechicken/nei/recipe/IRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/IRecipeHandler.java
@@ -85,11 +85,20 @@ public interface IRecipeHandler {
     List<PositionedStack> getOtherStacks(int recipe);
 
     /**
+     * Maintain this for backwards compatibility
      *
      * @param recipe The recipe index to get the result for.
      * @return The recipe result {@link PositionedStack} relative to the top left corner of your recipe drawing space.
      */
     PositionedStack getResultStack(int recipe);
+
+    /**
+     *
+     * @param recipe The recipe index to get the result for.
+     * @return A list of the result {@link PositionedStack}s relative to the top left corner of your recipe drawing
+     *         space.
+     */
+    List<PositionedStack> getResultStacks(int recipe);
 
     /**
      * A tick function called for updating progress bars and cycling damage items.

--- a/src/main/java/codechicken/nei/recipe/IRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/IRecipeHandler.java
@@ -83,10 +83,21 @@ public interface IRecipeHandler {
      * @return A list of the other {@link PositionedStack}s in this recipe relative to the top left corner of your
      *         recipe drawing space. For example fuel in furnaces.
      */
+    default List<PositionedStack> getExtraInputStacks(int recipe) {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Legacy API, define either {@link #getExtraInputStacks(int)} or {@link #getResultStacks(int)}
+     *
+     * @param recipe The recipe index to get items for.
+     * @return A list of the other {@link PositionedStack}s in this recipe relative to the top left corner of your
+     *         recipe drawing space. For example fuel in furnaces.
+     */
     List<PositionedStack> getOtherStacks(int recipe);
 
     /**
-     * Maintain this for backwards compatibility
+     * Legacy API, use {@link #getResultStacks(int) getResultStacks.get(0)} if you want the primary result
      *
      * @param recipe The recipe index to get the result for.
      * @return The recipe result {@link PositionedStack} relative to the top left corner of your recipe drawing space.

--- a/src/main/java/codechicken/nei/recipe/IRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/IRecipeHandler.java
@@ -1,5 +1,6 @@
 package codechicken.nei.recipe;
 
+import java.util.Collections;
 import java.util.List;
 
 import net.minecraft.client.gui.inventory.GuiContainer;
@@ -98,7 +99,10 @@ public interface IRecipeHandler {
      * @return A list of the result {@link PositionedStack}s relative to the top left corner of your recipe drawing
      *         space.
      */
-    List<PositionedStack> getResultStacks(int recipe);
+    default List<PositionedStack> getResultStacks(int recipe) {
+        final PositionedStack result = getResultStack(recipe);
+        return result != null ? Collections.singletonList(result) : Collections.emptyList();
+    }
 
     /**
      * A tick function called for updating progress bars and cycling damage items.

--- a/src/main/java/codechicken/nei/recipe/NEIRecipeWidget.java
+++ b/src/main/java/codechicken/nei/recipe/NEIRecipeWidget.java
@@ -202,6 +202,15 @@ public class NEIRecipeWidget extends Widget {
             drawItem(pStack, mouseX, mouseY, yShift, true);
         }
 
+        for (PositionedStack pStack : getExtraInputs()) {
+
+            if (!this.permutations.containsKey(pStack)) {
+                updatePermutationsFor(pStack);
+            }
+
+            drawItem(pStack, mouseX, mouseY, yShift, true);
+        }
+
         for (PositionedStack pStack : getCatalysts()) {
 
             if (!this.permutations.containsKey(pStack)) {
@@ -491,7 +500,7 @@ public class NEIRecipeWidget extends Widget {
             final int stackIndex = indexOf(items, overStack.item);
             final ItemStack stack = items.get((items.size() - scroll + stackIndex) % items.size());
 
-            Stream.concat(getInputs().stream(), getCatalysts().stream()).filter(pStack -> pStack.containsWithNBT(stack))
+            Stream.concat(getInputs().stream(), Stream.concat(getExtraInputs().stream(), getCatalysts().stream())).filter(pStack -> pStack.containsWithNBT(stack))
                     .forEach(pStack -> pStack.setPermutationToRender(stack));
 
             if (this.acceptsFollowingTooltipLineHandler != null) {
@@ -554,6 +563,12 @@ public class NEIRecipeWidget extends Widget {
             }
         }
 
+        for (PositionedStack pStack : getExtraInputs()) {
+            if (pStack.contains(mx - this.x, my - this.y - yShift)) {
+                return pStack;
+            }
+        }
+
         for (PositionedStack pStack : getCatalysts()) {
             if (pStack.contains(mx - this.x, my - this.y - yShift)) {
                 return pStack;
@@ -610,6 +625,10 @@ public class NEIRecipeWidget extends Widget {
             updatePermutationsFor(pStack);
         }
 
+        for (PositionedStack pStack : getExtraInputs()) {
+            updatePermutationsFor(pStack);
+        }
+
         for (PositionedStack pStack : getCatalysts()) {
             updatePermutationsFor(pStack);
         }
@@ -655,10 +674,14 @@ public class NEIRecipeWidget extends Widget {
         return this.handlerRef.handler.getIngredientStacks(this.handlerRef.recipeIndex);
     }
 
+    protected List<PositionedStack> getExtraInputs() {
+        return this.handlerRef.handler.getExtraInputStacks(this.handlerRef.recipeIndex);
+    }
+
     protected List<PositionedStack> getOutputs() {
         final List<PositionedStack> pStackResults = this.handlerRef.handler
                 .getResultStacks(this.handlerRef.recipeIndex);
-        return pStackResults.isEmpty() ? pStackResults
+        return !pStackResults.isEmpty() ? pStackResults
                 : this.handlerRef.handler.getOtherStacks(this.handlerRef.recipeIndex);
     }
 

--- a/src/main/java/codechicken/nei/recipe/NEIRecipeWidget.java
+++ b/src/main/java/codechicken/nei/recipe/NEIRecipeWidget.java
@@ -656,8 +656,9 @@ public class NEIRecipeWidget extends Widget {
     }
 
     protected List<PositionedStack> getOutputs() {
-        final PositionedStack pStackResult = this.handlerRef.handler.getResultStack(this.handlerRef.recipeIndex);
-        return pStackResult != null ? Arrays.asList(pStackResult)
+        final List<PositionedStack> pStackResults = this.handlerRef.handler
+                .getResultStacks(this.handlerRef.recipeIndex);
+        return pStackResults != null ? pStackResults
                 : this.handlerRef.handler.getOtherStacks(this.handlerRef.recipeIndex);
     }
 

--- a/src/main/java/codechicken/nei/recipe/NEIRecipeWidget.java
+++ b/src/main/java/codechicken/nei/recipe/NEIRecipeWidget.java
@@ -202,15 +202,6 @@ public class NEIRecipeWidget extends Widget {
             drawItem(pStack, mouseX, mouseY, yShift, true);
         }
 
-        for (PositionedStack pStack : getExtraInputs()) {
-
-            if (!this.permutations.containsKey(pStack)) {
-                updatePermutationsFor(pStack);
-            }
-
-            drawItem(pStack, mouseX, mouseY, yShift, true);
-        }
-
         for (PositionedStack pStack : getCatalysts()) {
 
             if (!this.permutations.containsKey(pStack)) {
@@ -500,7 +491,7 @@ public class NEIRecipeWidget extends Widget {
             final int stackIndex = indexOf(items, overStack.item);
             final ItemStack stack = items.get((items.size() - scroll + stackIndex) % items.size());
 
-            Stream.concat(getInputs().stream(), Stream.concat(getExtraInputs().stream(), getCatalysts().stream())).filter(pStack -> pStack.containsWithNBT(stack))
+            Stream.concat(getInputs().stream(), getCatalysts().stream()).filter(pStack -> pStack.containsWithNBT(stack))
                     .forEach(pStack -> pStack.setPermutationToRender(stack));
 
             if (this.acceptsFollowingTooltipLineHandler != null) {
@@ -563,12 +554,6 @@ public class NEIRecipeWidget extends Widget {
             }
         }
 
-        for (PositionedStack pStack : getExtraInputs()) {
-            if (pStack.contains(mx - this.x, my - this.y - yShift)) {
-                return pStack;
-            }
-        }
-
         for (PositionedStack pStack : getCatalysts()) {
             if (pStack.contains(mx - this.x, my - this.y - yShift)) {
                 return pStack;
@@ -625,10 +610,6 @@ public class NEIRecipeWidget extends Widget {
             updatePermutationsFor(pStack);
         }
 
-        for (PositionedStack pStack : getExtraInputs()) {
-            updatePermutationsFor(pStack);
-        }
-
         for (PositionedStack pStack : getCatalysts()) {
             updatePermutationsFor(pStack);
         }
@@ -674,10 +655,6 @@ public class NEIRecipeWidget extends Widget {
         return this.handlerRef.handler.getIngredientStacks(this.handlerRef.recipeIndex);
     }
 
-    protected List<PositionedStack> getExtraInputs() {
-        return this.handlerRef.handler.getExtraInputStacks(this.handlerRef.recipeIndex);
-    }
-
     protected List<PositionedStack> getOutputs() {
         final List<PositionedStack> pStackResults = this.handlerRef.handler
                 .getResultStacks(this.handlerRef.recipeIndex);
@@ -686,6 +663,11 @@ public class NEIRecipeWidget extends Widget {
     }
 
     protected List<PositionedStack> getCatalysts() {
+        List<PositionedStack> catalysts = this.handlerRef.handler.getCatalystStacks(this.handlerRef.recipeIndex);
+        if (!catalysts.isEmpty()) {
+            return catalysts;
+        }
+
         if (this.handlerRef.handler.getResultStacks(this.handlerRef.recipeIndex).isEmpty()) {
             return Collections.emptyList();
         }

--- a/src/main/java/codechicken/nei/recipe/NEIRecipeWidget.java
+++ b/src/main/java/codechicken/nei/recipe/NEIRecipeWidget.java
@@ -658,12 +658,12 @@ public class NEIRecipeWidget extends Widget {
     protected List<PositionedStack> getOutputs() {
         final List<PositionedStack> pStackResults = this.handlerRef.handler
                 .getResultStacks(this.handlerRef.recipeIndex);
-        return pStackResults != null ? pStackResults
+        return pStackResults.isEmpty() ? pStackResults
                 : this.handlerRef.handler.getOtherStacks(this.handlerRef.recipeIndex);
     }
 
     protected List<PositionedStack> getCatalysts() {
-        if (this.handlerRef.handler.getResultStack(this.handlerRef.recipeIndex) == null) {
+        if (this.handlerRef.handler.getResultStacks(this.handlerRef.recipeIndex).isEmpty()) {
             return Collections.emptyList();
         }
         return this.handlerRef.handler.getOtherStacks(this.handlerRef.recipeIndex);

--- a/src/main/java/codechicken/nei/recipe/NEIRecipeWidget.java
+++ b/src/main/java/codechicken/nei/recipe/NEIRecipeWidget.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -36,6 +37,7 @@ import codechicken.nei.recipe.GuiRecipeButton.UpdateRecipeButtonsEvent;
 import codechicken.nei.recipe.Recipe.RecipeId;
 import codechicken.nei.recipe.debug.DebugHandlerWidget;
 import codechicken.nei.util.NEIMouseUtils;
+import it.unimi.dsi.fastutil.longs.LongArraySet;
 
 public class NEIRecipeWidget extends Widget {
 
@@ -53,6 +55,9 @@ public class NEIRecipeWidget extends Widget {
 
     protected boolean showAsWidget = false;
     protected List<GuiRecipeButton> recipeButtons = null;
+
+    // Handles re-draws for catalysts-outputs duplication to preserve full backward compatibility for otherStacks
+    private final Set<Long> drawnSlots = new LongArraySet();
 
     public NEIRecipeWidget(RecipeHandlerRef handlerRef) {
         this.handlerRef = handlerRef;
@@ -193,26 +198,38 @@ public class NEIRecipeWidget extends Widget {
 
         GuiContainerManager.enableMatrixStackLogging();
 
-        for (PositionedStack pStack : getInputs()) {
+        final List<PositionedStack> inputs = getInputs();
+        final List<PositionedStack> catalysts = getCatalysts();
+        final List<PositionedStack> outputs = getOutputs();
 
-            if (!this.permutations.containsKey(pStack)) {
-                updatePermutationsFor(pStack);
-            }
-
-            drawItem(pStack, mouseX, mouseY, yShift, true);
-        }
-
-        for (PositionedStack pStack : getCatalysts()) {
-
-            if (!this.permutations.containsKey(pStack)) {
-                updatePermutationsFor(pStack);
-            }
-
-            drawItem(pStack, mouseX, mouseY, yShift, true);
-        }
-
-        for (PositionedStack pStack : getOutputs()) {
+        drawnSlots.clear();
+        for (PositionedStack pStack : inputs) {
+            drawnSlots.add(slotKey(pStack));
             drawItem(pStack, mouseX, mouseY, yShift, false);
+        }
+
+        for (PositionedStack pStack : catalysts) {
+            if (!drawnSlots.add(slotKey(pStack))) {
+                continue;
+            }
+
+            if (!this.permutations.containsKey(pStack)) {
+                updatePermutationsFor(pStack);
+            }
+
+            drawItem(pStack, mouseX, mouseY, yShift, true);
+        }
+
+        for (PositionedStack pStack : outputs) {
+            if (!drawnSlots.add(slotKey(pStack))) {
+                continue;
+            }
+
+            if (!this.permutations.containsKey(pStack)) {
+                updatePermutationsFor(pStack);
+            }
+
+            drawItem(pStack, mouseX, mouseY, yShift, true);
         }
 
         GuiContainerManager.disableMatrixStackLogging();
@@ -244,6 +261,10 @@ public class NEIRecipeWidget extends Widget {
         }
 
         DebugHandlerWidget.instance.drawGuiPlaceholder(this);
+    }
+
+    private static long slotKey(PositionedStack pStack) {
+        return ((long) pStack.relx << 32) ^ (pStack.rely & 0xFFFFFFFFL);
     }
 
     protected void drawItem(PositionedStack pStack, int mouseX, int mouseY, int yShift, boolean input) {

--- a/src/main/java/codechicken/nei/recipe/ProfilerRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/ProfilerRecipeHandler.java
@@ -193,11 +193,6 @@ public class ProfilerRecipeHandler implements ICraftingHandler, IUsageHandler {
     }
 
     @Override
-    public List<PositionedStack> getResultStacks(int recipe) {
-        return new ArrayList<>();
-    }
-
-    @Override
     public void onUpdate() {}
 
     @Override

--- a/src/main/java/codechicken/nei/recipe/ProfilerRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/ProfilerRecipeHandler.java
@@ -193,6 +193,11 @@ public class ProfilerRecipeHandler implements ICraftingHandler, IUsageHandler {
     }
 
     @Override
+    public List<PositionedStack> getResultStacks(int recipe) {
+        return new ArrayList<>();
+    }
+
+    @Override
     public void onUpdate() {}
 
     @Override

--- a/src/main/java/codechicken/nei/recipe/Recipe.java
+++ b/src/main/java/codechicken/nei/recipe/Recipe.java
@@ -70,7 +70,10 @@ public class Recipe {
                 }
             }
 
-            return new RecipeId(extractItem(pStackResults.get(0)), handlerName, extractIngredients(ingredients));
+            return new RecipeId(
+                    extractItem(!pStackResults.isEmpty() ? pStackResults.get(0) : null),
+                    handlerName,
+                    extractIngredients(ingredients));
         }
 
         public static RecipeId of(JsonObject json) {

--- a/src/main/java/codechicken/nei/recipe/Recipe.java
+++ b/src/main/java/codechicken/nei/recipe/Recipe.java
@@ -54,19 +54,19 @@ public class Recipe {
         public static RecipeId of(IRecipeHandler handler, int recipeIndex) {
             final List<PositionedStack> ingredients = handler.getIngredientStacks(recipeIndex);
             final String handlerName = GuiRecipeTab.getHandlerInfo(handler).getHandlerName();
-            PositionedStack pStackResult = handler.getResultStack(recipeIndex);
+            List<PositionedStack> pStackResults = handler.getResultStacks(recipeIndex);
 
-            if (pStackResult == null) {
+            if (pStackResults.isEmpty()) {
                 for (PositionedStack otherStack : handler.getOtherStacks(recipeIndex)) {
                     if (!FluidContainerRegistry.isContainer(otherStack.items[0])
                             || StackInfo.getFluid(otherStack.items[0]) != null) {
-                        pStackResult = otherStack;
+                        pStackResults.add(otherStack);
                         break;
                     }
                 }
             }
 
-            return new RecipeId(extractItem(pStackResult), handlerName, extractIngredients(ingredients));
+            return new RecipeId(extractItem(pStackResults), handlerName, extractIngredients(ingredients));
         }
 
         public static RecipeId of(JsonObject json) {
@@ -389,8 +389,12 @@ public class Recipe {
             ingredients.add(RecipeIngredient.of(positionedStack));
         }
 
-        if (handler.getResultStack(recipeIndex) != null) {
-            results.add(RecipeIngredient.of(handler.getResultStack(recipeIndex)));
+        final List<PositionedStack> resultStacks = handler.getResultStacks(recipeIndex);
+
+        if (!resultStacks.isEmpty()) {
+            for (PositionedStack positionedStack : resultStacks) {
+                results.add(RecipeIngredient.of(positionedStack));
+            }
         } else {
             for (PositionedStack positionedStack : handler.getOtherStacks(recipeIndex)) {
                 results.add(RecipeIngredient.of(positionedStack));

--- a/src/main/java/codechicken/nei/recipe/Recipe.java
+++ b/src/main/java/codechicken/nei/recipe/Recipe.java
@@ -54,6 +54,10 @@ public class Recipe {
         public static RecipeId of(IRecipeHandler handler, int recipeIndex) {
             final List<PositionedStack> ingredients = handler.getIngredientStacks(recipeIndex);
             final String handlerName = GuiRecipeTab.getHandlerInfo(handler).getHandlerName();
+            // Use getResultStacks even though getResult could work because if a handler, like GT for example, doesn't
+            // return anything from getResult, but will define all the outputs in getResultStacks we can still pick up
+            // the results here. If a handler still doesn't define getResultStacks, then it will naturally fall back to
+            // getResult anyway
             List<PositionedStack> pStackResults = handler.getResultStacks(recipeIndex);
 
             if (pStackResults.isEmpty()) {
@@ -66,7 +70,7 @@ public class Recipe {
                 }
             }
 
-            return new RecipeId(extractItem(pStackResults), handlerName, extractIngredients(ingredients));
+            return new RecipeId(extractItem(pStackResults.get(0)), handlerName, extractIngredients(ingredients));
         }
 
         public static RecipeId of(JsonObject json) {

--- a/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
@@ -4,6 +4,7 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -650,7 +651,7 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
         try {
             return arecipes.get(recipe).getResults();
         } catch (ArrayIndexOutOfBoundsException ignored) {
-            return null;
+            return Collections.emptyList();
         }
     }
 

--- a/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
@@ -54,12 +54,6 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
 
     protected static ReentrantLock lock = new ReentrantLock();
 
-    /**
-     * To be used when creating a recipe handler to maintain backwards compatibility for NEI addons, if true the handler
-     * must not use `getResultStacks`, falling back to using the `other slots` as extra outputs
-     */
-    private final boolean canUseNewSlotLayout;
-
     public static void findFuelsOnce() {
         // Ensure we only find fuels once, even if threaded
         lock.lock();
@@ -152,6 +146,15 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
                 NEIClientConfig.logger.error("Error in getOtherStacks: " + e);
             }
             return stacks;
+        }
+
+        /**
+         * The ingredients required to produce the result Use this if you have more than one ingredient
+         *
+         * @return A list of positioned ingredient items.
+         */
+        public List<PositionedStack> getExtraInputs() {
+            return Collections.emptyList();
         }
 
         /**
@@ -404,9 +407,7 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
      */
     public LinkedList<RecipeTransferRect> transferRects = new LinkedList<>();
 
-    public TemplateRecipeHandler(boolean canUseNewSlotLayout) {
-        this.canUseNewSlotLayout = canUseNewSlotLayout;
-
+    public TemplateRecipeHandler() {
         try {
             loadTransferRects();
             RecipeTransferRectHandler.registerRectsToGuis(getRecipeTransferRectGuis(), transferRects);
@@ -414,10 +415,6 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
             NEIClientConfig.logger
                     .error("NEI: Failed to load transfer rects for {}: {}", getClass().getName(), e.toString());
         }
-    }
-
-    public TemplateRecipeHandler() {
-        this(false);
     }
 
     /**
@@ -667,6 +664,14 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
         }
     }
 
+    public List<PositionedStack> getExtraInputStacks(int recipe) {
+        try {
+            return arecipes.get(recipe).getExtraInputs();
+        } catch (ArrayIndexOutOfBoundsException ignored) {
+            return Collections.emptyList();
+        }
+    }
+
     public List<PositionedStack> getOtherStacks(int recipe) {
         return arecipes.get(recipe).getOtherStacks();
     }
@@ -732,14 +737,6 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
     @Override
     public boolean mouseScrolled(GuiRecipe<?> gui, int scroll, int recipe) {
         return false;
-    }
-
-    /**
-     *
-     * @return true if the recipe supports returning multiple results via `getResultStacks`
-     */
-    public boolean canUseNewSlotLayout() {
-        return canUseNewSlotLayout;
     }
 
     private boolean transferRect(GuiRecipe<?> gui, int recipe, boolean usage) {

--- a/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
@@ -149,16 +149,32 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
         }
 
         /**
-         * The ingredients required to produce the result Use this if you have more than one ingredient
+         * Return extra items that are not directly involved in the ingredient->result relationship. Eg fuels.
          *
          * @return A list of positioned ingredient items.
          */
-        public List<PositionedStack> getExtraInputs() {
-            return Collections.emptyList();
+        public List<PositionedStack> getCatalysts() {
+            ArrayList<PositionedStack> stacks = new ArrayList<>();
+            try {
+                PositionedStack stack = getCatalyst();
+                if (stack != null) stacks.add(stack);
+            } catch (ArithmeticException e) {
+                NEIClientConfig.logger.error("Error in getCatalysts: " + e);
+            }
+            return stacks;
         }
 
         /**
-         * The ingredients required to produce the result Use this if you have more than one ingredient
+         * Simple utility
+         *
+         * @return The another positioned stack
+         */
+        public PositionedStack getCatalyst() {
+            return null;
+        }
+
+        /**
+         * The ingredients required to produce the result. Use this if you have more than one ingredient
          *
          * @return A list of positioned ingredient items.
          */
@@ -177,6 +193,8 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
         }
 
         /**
+         * Legacy API
+         *
          * Return extra items that are not directly involved in the ingredient->result relationship. Eg fuels. Use this
          * if you have more than one other stack
          *
@@ -664,12 +682,8 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
         }
     }
 
-    public List<PositionedStack> getExtraInputStacks(int recipe) {
-        try {
-            return arecipes.get(recipe).getExtraInputs();
-        } catch (ArrayIndexOutOfBoundsException ignored) {
-            return Collections.emptyList();
-        }
+    public List<PositionedStack> getCatalystStacks(int recipe) {
+        return arecipes.get(recipe).getCatalysts();
     }
 
     public List<PositionedStack> getOtherStacks(int recipe) {

--- a/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
@@ -54,6 +54,12 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
 
     protected static ReentrantLock lock = new ReentrantLock();
 
+    /**
+     * To be used when creating a recipe handler to maintain backwards compatibility for NEI addons, if true the handler
+     * must not use `getResultStacks`, falling back to using the `other slots` as extra outputs
+     */
+    private final boolean canUseNewSlotLayout;
+
     public static void findFuelsOnce() {
         // Ensure we only find fuels once, even if threaded
         lock.lock();
@@ -398,7 +404,9 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
      */
     public LinkedList<RecipeTransferRect> transferRects = new LinkedList<>();
 
-    public TemplateRecipeHandler() {
+    public TemplateRecipeHandler(boolean canUseNewSlotLayout) {
+        this.canUseNewSlotLayout = canUseNewSlotLayout;
+
         try {
             loadTransferRects();
             RecipeTransferRectHandler.registerRectsToGuis(getRecipeTransferRectGuis(), transferRects);
@@ -406,6 +414,10 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
             NEIClientConfig.logger
                     .error("NEI: Failed to load transfer rects for {}: {}", getClass().getName(), e.toString());
         }
+    }
+
+    public TemplateRecipeHandler() {
+        this(false);
     }
 
     /**
@@ -720,6 +732,14 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
     @Override
     public boolean mouseScrolled(GuiRecipe<?> gui, int scroll, int recipe) {
         return false;
+    }
+
+    /**
+     *
+     * @return true if the recipe supports returning multiple results via `getResultStacks`
+     */
+    public boolean canUseNewSlotLayout() {
+        return canUseNewSlotLayout;
     }
 
     private boolean transferRect(GuiRecipe<?> gui, int recipe, boolean usage) {

--- a/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/TemplateRecipeHandler.java
@@ -132,6 +132,22 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
         public abstract PositionedStack getResult();
 
         /**
+         * The multiple items produced by this recipe, with position
+         *
+         * @return A list of positioned ingredient items.
+         */
+        public List<PositionedStack> getResults() {
+            ArrayList<PositionedStack> stacks = new ArrayList<>();
+            try {
+                PositionedStack stack = getResult();
+                if (stack != null) stacks.add(stack);
+            } catch (ArithmeticException e) {
+                NEIClientConfig.logger.error("Error in getOtherStacks: " + e);
+            }
+            return stacks;
+        }
+
+        /**
          * The ingredients required to produce the result Use this if you have more than one ingredient
          *
          * @return A list of positioned ingredient items.
@@ -625,8 +641,14 @@ public abstract class TemplateRecipeHandler implements ICraftingHandler, IUsageH
     }
 
     public PositionedStack getResultStack(int recipe) {
+        List<PositionedStack> results = getResultStacks(recipe);
+        if (results == null || results.isEmpty()) return null;
+        return results.get(0);
+    }
+
+    public List<PositionedStack> getResultStacks(int recipe) {
         try {
-            return arecipes.get(recipe).getResult();
+            return arecipes.get(recipe).getResults();
         } catch (ArrayIndexOutOfBoundsException ignored) {
             return null;
         }


### PR DESCRIPTION
## Summary

This pr allows recipes to provide multiple outputs without routing everything into the other stacks. This would fix a bandaid solution in plannh, but I'm sure there could be other benefits.

To test this I booted a modified version of GT5 in a dev env and everything seems to work, but I will do more testing later. I'm opening this pr early to see if this change is, first of all, welcome since it could have unintended regressions.

gt pr: https://github.com/GTNewHorizons/GT5-Unofficial/pull/7426
enderio pr: https://github.com/GTNewHorizons/EnderIO/pull/241

When everything is correct I will proceed to update other mods that might benefit from this change (like enderIO, but there might be more)

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
