### PR TITLE
Avoid stream allocations in ItemsGrid slot lookups

### DIFF
--- a/src/main/java/codechicken/nei/ItemsGrid.java
+++ b/src/main/java/codechicken/nei/ItemsGrid.java
@@ -458,11 +458,31 @@ public abstract class ItemsGrid<T extends ItemsGrid.ItemsGridSlot, M extends Ite
     }
 
     public T getSlotBySlotIndex(int slotIndex) {
-        return getMask().stream().filter(item -> item.slotIndex == slotIndex).findAny().orElse(null);
+        final List<T> mask = getMask();
+
+        for (int i = 0; i < mask.size(); i++) {
+            final T item = mask.get(i);
+
+            if (item.slotIndex == slotIndex) {
+                return item;
+            }
+        }
+
+        return null;
     }
 
     public T getSlotByItemIndex(int itemIndex) {
-        return getMask().stream().filter(item -> item.itemIndex == itemIndex).findAny().orElse(null);
+        final List<T> mask = getMask();
+
+        for (int i = 0; i < mask.size(); i++) {
+            final T item = mask.get(i);
+
+            if (item.itemIndex == itemIndex) {
+                return item;
+            }
+        }
+
+        return null;
     }
 
     public Rectangle4i getItemRect(int itemIndex) {


### PR DESCRIPTION
Ref #823, where the review note suggested avoiding streams in hot paths.

`ItemsGrid.getSlotBySlotIndex` / `getSlotByItemIndex` allocated a stream, two lambdas, and an `Optional` on every call. Both sit in per-frame paths: `getSlotMouseOver` runs from every panel's `getMouseContext` on each `draw`, from tooltip handling while hovering, and from the drag/click handlers - once per visible panel (item panel, bookmarks, history, craftables).

This replaces the stream pipeline with an indexed loop over the cached grid mask. Same first-match semantics, zero per-call allocation.

Scope note: this reduces allocation pressure in the profiled hot path; it is not claimed to resolve the off-heap/RSS growth reported in #823, which may not be heap-related at all.

Verified with `gradlew spotlessCheck compileJava` (BUILD SUCCESSFUL).