### PR TITLE
Fix GL reset

### DIFF
--- a/src/main/java/codechicken/nei/WorldOverlayRenderer.java
+++ b/src/main/java/codechicken/nei/WorldOverlayRenderer.java
@@ -60,6 +60,7 @@ public class WorldOverlayRenderer implements IKeyStateTracker {
     }
 
     public static void render(float frame) {
+        GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT | GL11.GL_DEPTH_BUFFER_BIT | GL11.GL_LINE_BIT);
         GL11.glPushMatrix();
         Entity entity = Minecraft.getMinecraft().renderViewEntity;
 
@@ -73,9 +74,12 @@ public class WorldOverlayRenderer implements IKeyStateTracker {
 
         GL11.glTranslated(-interpPosX + intOffsetX, -interpPosY + intOffsetY, -interpPosZ + intOffsetZ);
 
+        GL11.glEnable(GL11.GL_DEPTH_TEST);
+        GL11.glDepthFunc(GL11.GL_LEQUAL);
         renderChunkBounds(entity, intOffsetX, intOffsetY, intOffsetZ);
         renderMobSpawnOverlay(entity, intOffsetX, intOffsetY, intOffsetZ);
         GL11.glPopMatrix();
+        GL11.glPopAttrib();
     }
 
     private static void buildMobSpawnOverlay(Entity entity) {


### PR DESCRIPTION
## Summary
Add some missing GL reset that affect F7 and F9 overlays

When the F9 one is enabled it seem to dim things like the powerfail alerts.
And the F7 sometimes show through walls when similar things get rendered by another mod (findit T search, I'll PR it too)

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
