### PR TITLE
Overlay Button moves one item if the recipe stack is size zero

### DIFF
--- a/src/main/java/codechicken/nei/recipe/DefaultOverlayHandler.java
+++ b/src/main/java/codechicken/nei/recipe/DefaultOverlayHandler.java
@@ -210,7 +210,7 @@ public class DefaultOverlayHandler implements IOverlayHandler {
 
             for (IngredientDistribution distrib : assignedIngredients) {
                 if (distrib.slots.length == 0 || !slot.getHasStack() || !canStack(distrib.permutation, stack)) continue;
-                int transferCap = Math.min(slotTransferCap, multiplier * distrib.permutation.stackSize);
+                int transferCap = Math.min(slotTransferCap, Math.max(multiplier * distrib.permutation.stackSize, 1));
                 int stackSize = slot.getStack().stackSize;
                 boolean pickup = false;
 


### PR DESCRIPTION
I noticed while making https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1879 and an upcoming Blood Magic PR that the overlay handler will not move items if the stack in the recipe is size zero. This fixes that by always moving a minimum of one item:

https://github.com/user-attachments/assets/2970f211-4e90-4f62-904b-83576be6ca75

https://github.com/user-attachments/assets/e4e92e9a-c9e6-4337-8955-657815752dd5

`multiplier` should [never be 0](https://github.com/GTNewHorizons/NotEnoughItems/blob/master/src/main/java/codechicken/nei/recipe/DefaultOverlayHandler.java#L83), so this should only change behavior for recipes with size 0 stacks. Behavior is unchanged if the recipe item is not present in the inventory (it won't create a new item ex nihilo or anything).