### PR TITLE
Add ramp up based crafting throttle to autocrafting

### DIFF
--- a/src/main/java/codechicken/nei/recipe/AutoCraftingManager.java
+++ b/src/main/java/codechicken/nei/recipe/AutoCraftingManager.java
@@ -50,9 +50,19 @@ public class AutoCraftingManager {
                             long multiplier = entry.getValue();
 
                             while (multiplier > 0 && !interrupted(guiContainer)) {
-                                sleepInterruptibly(throttle.nextDelayMs(entry.getKey()), guiContainer);
-                                if (interrupted(guiContainer) || !handler.craft(guiContainer, 1)) break;
-                                multiplier -= 1;
+                                final CraftRampThrottle.Tick tick = throttle.next(entry.getKey());
+                                sleepInterruptibly(tick.delayMs, guiContainer);
+                                if (interrupted(guiContainer)) break;
+
+                                boolean crafted = false;
+                                for (int i = 0; i < tick.crafts && multiplier > 0
+                                        && !interrupted(guiContainer); i++) {
+                                    if (!handler.craft(guiContainer, 1)) break;
+                                    multiplier -= 1;
+                                    crafted = true;
+                                }
+
+                                if (!crafted) break; // output couldn't be taken (e.g. inventory full)
                             }
 
                             craft = multiplier != entry.getValue();

--- a/src/main/java/codechicken/nei/recipe/AutoCraftingManager.java
+++ b/src/main/java/codechicken/nei/recipe/AutoCraftingManager.java
@@ -29,6 +29,7 @@ public class AutoCraftingManager {
             final List<BookmarkItem> initialItems = prepareInitialItems(math, getInventoryItems(guiContainer));
             boolean processed = false;
             boolean changed = false;
+            final CraftRampThrottle throttle = new CraftRampThrottle();
 
             StackInfo.pauseItemDamageSound(true);
 
@@ -48,9 +49,10 @@ public class AutoCraftingManager {
                         if (handler != null && handler.canCraft(guiContainer)) {
                             long multiplier = entry.getValue();
 
-                            while (multiplier > 0 && !interrupted(guiContainer)
-                                    && handler.craft(guiContainer, (int) Math.min(64, multiplier))) {
-                                multiplier -= 64;
+                            while (multiplier > 0 && !interrupted(guiContainer)) {
+                                sleepInterruptibly(throttle.nextDelayMs(entry.getKey()), guiContainer);
+                                if (interrupted(guiContainer) || !handler.craft(guiContainer, 1)) break;
+                                multiplier -= 1;
                             }
 
                             craft = multiplier != entry.getValue();
@@ -84,6 +86,19 @@ public class AutoCraftingManager {
 
         private boolean interrupted(GuiContainer guiContainer) {
             return interrupted() || guiContainer != NEIClientUtils.getGuiContainer();
+        }
+
+        private void sleepInterruptibly(long delayMs, GuiContainer guiContainer) {
+            long remaining = delayMs;
+            while (remaining > 0 && !interrupted(guiContainer)) {
+                final long chunk = Math.min(20L, remaining);
+                try {
+                    Thread.sleep(chunk);
+                } catch (InterruptedException ignored) {
+                    return;
+                }
+                remaining -= chunk;
+            }
         }
 
         private List<BookmarkItem> prepareInitialItems(RecipeChainMath math, ItemStackAmount inventory) {

--- a/src/main/java/codechicken/nei/recipe/AutoCraftingManager.java
+++ b/src/main/java/codechicken/nei/recipe/AutoCraftingManager.java
@@ -55,8 +55,7 @@ public class AutoCraftingManager {
                                 if (interrupted(guiContainer)) break;
 
                                 boolean crafted = false;
-                                for (int i = 0; i < tick.crafts && multiplier > 0
-                                        && !interrupted(guiContainer); i++) {
+                                for (int i = 0; i < tick.crafts && multiplier > 0 && !interrupted(guiContainer); i++) {
                                     if (!handler.craft(guiContainer, 1)) break;
                                     multiplier -= 1;
                                     crafted = true;

--- a/src/main/java/codechicken/nei/recipe/CraftRampThrottle.java
+++ b/src/main/java/codechicken/nei/recipe/CraftRampThrottle.java
@@ -1,0 +1,33 @@
+package codechicken.nei.recipe;
+
+import java.util.Objects;
+
+import codechicken.nei.recipe.Recipe.RecipeId;
+
+/**
+ * Per-craft delay ramp for auto-crafting. First craft of a recipe is instant,
+ * then the delay decays geometrically toward a floor. Changing the recipe
+ * resets the ramp. Pure logic; does not sleep.
+ */
+public class CraftRampThrottle {
+
+    public static final long START_DELAY_MS = 500L; // delay before the 2nd craft
+    public static final long FLOOR_DELAY_MS = 50L;  // fastest allowed (cap)
+    public static final double DECAY = 0.85D;
+
+    private RecipeId current;
+    private long delayMs;
+
+    /** Delay to wait before the next craft of {@code id}; 0 for the first / after a change. */
+    public long nextDelayMs(RecipeId id) {
+        if (!Objects.equals(id, this.current)) {
+            this.current = id;
+            this.delayMs = START_DELAY_MS;
+            return 0L;
+        }
+
+        final long delay = this.delayMs;
+        this.delayMs = Math.max(FLOOR_DELAY_MS, Math.round(this.delayMs * DECAY));
+        return delay;
+    }
+}

--- a/src/main/java/codechicken/nei/recipe/CraftRampThrottle.java
+++ b/src/main/java/codechicken/nei/recipe/CraftRampThrottle.java
@@ -1,22 +1,23 @@
 package codechicken.nei.recipe;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Objects;
 
 import codechicken.nei.recipe.Recipe.RecipeId;
 
 /**
- * Per-craft delay ramp for auto-crafting. A recipe starts at the start delay and
- * decays geometrically toward a floor. Each recipe keeps its own ramp for the
- * run, so switching away and back resumes rather than restarts. At floor (max)
- * speed crafts are batched. Pure logic; does not sleep.
+ * Per-craft delay ramp for auto-crafting. Crafting a recipe repeatedly speeds up
+ * (delay decays geometrically toward a floor). Momentum is global: switching to
+ * a different recipe reduces speed by a penalty but does not reset it, so going
+ * back to a recipe resumes with most of its momentum. At floor (max) speed
+ * crafts are batched. Pure logic; does not sleep.
  */
 public class CraftRampThrottle {
 
-    public static final long START_DELAY_MS = 500L; // delay before the 1st craft
-    public static final long FLOOR_DELAY_MS = 50L;  // fastest allowed (cap)
-    public static final double DECAY = 0.85D;
-    public static final int BULK_CRAFTS = 8;        // crafts per tick once maxed out
+    public static final long START_DELAY_MS = 300L; // delay before the 1st craft
+    public static final long FLOOR_DELAY_MS = 100L; // fastest allowed (cap)
+    public static final double DECAY = 0.88D;       // per-craft speedup
+    public static final double SWITCH_PENALTY = 2.0D; // momentum lost on recipe change
+    public static final int BULK_CRAFTS = 4;        // crafts per tick once maxed out
 
     /** Delay to wait before a craft, and how many crafts that tick covers. */
     public static final class Tick {
@@ -30,12 +31,20 @@ public class CraftRampThrottle {
         }
     }
 
-    private final Map<RecipeId, Long> delays = new HashMap<>();
+    private RecipeId current;
+    private long delayMs = START_DELAY_MS;
 
-    /** Next tick for {@code id}: the start delay the first time, then a decaying delay. */
+    /** Next tick for {@code id}: decays on repeat, slows (but keeps momentum) on a recipe change. */
     public Tick next(RecipeId id) {
-        final long delay = this.delays.getOrDefault(id, START_DELAY_MS);
-        this.delays.put(id, Math.max(FLOOR_DELAY_MS, Math.round(delay * DECAY)));
-        return new Tick(delay, delay == FLOOR_DELAY_MS ? BULK_CRAFTS : 1);
+        if (!Objects.equals(id, this.current)) {
+            if (this.current != null) {
+                this.delayMs = Math.min(START_DELAY_MS, Math.round(this.delayMs * SWITCH_PENALTY));
+            }
+            this.current = id;
+        }
+
+        final long delay = this.delayMs;
+        this.delayMs = Math.max(FLOOR_DELAY_MS, Math.round(delay * DECAY));
+        return new Tick(delay, delay <= FLOOR_DELAY_MS ? BULK_CRAFTS : 1);
     }
 }

--- a/src/main/java/codechicken/nei/recipe/CraftRampThrottle.java
+++ b/src/main/java/codechicken/nei/recipe/CraftRampThrottle.java
@@ -5,19 +5,18 @@ import java.util.Objects;
 import codechicken.nei.recipe.Recipe.RecipeId;
 
 /**
- * Per-craft delay ramp for auto-crafting. Crafting a recipe repeatedly speeds up
- * (delay decays geometrically toward a floor). Momentum is global: switching to
- * a different recipe reduces speed by a penalty but does not reset it, so going
- * back to a recipe resumes with most of its momentum. At floor (max) speed
- * crafts are batched. Pure logic; does not sleep.
+ * Per-craft delay ramp for auto-crafting. Crafting a recipe repeatedly speeds up (delay decays geometrically toward a
+ * floor). Momentum is global: switching to a different recipe reduces speed by a penalty but does not reset it, so
+ * going back to a recipe resumes with most of its momentum. At floor (max) speed crafts are batched. Pure logic; does
+ * not sleep.
  */
 public class CraftRampThrottle {
 
     public static final long START_DELAY_MS = 300L; // delay before the 1st craft
     public static final long FLOOR_DELAY_MS = 100L; // fastest allowed (cap)
-    public static final double DECAY = 0.88D;       // per-craft speedup
+    public static final double DECAY = 0.88D; // per-craft speedup
     public static final double SWITCH_PENALTY = 2.0D; // momentum lost on recipe change
-    public static final int BULK_CRAFTS = 4;        // crafts per tick once maxed out
+    public static final int BULK_CRAFTS = 4; // crafts per tick once maxed out
 
     /** Delay to wait before a craft, and how many crafts that tick covers. */
     public static final class Tick {

--- a/src/main/java/codechicken/nei/recipe/CraftRampThrottle.java
+++ b/src/main/java/codechicken/nei/recipe/CraftRampThrottle.java
@@ -6,14 +6,14 @@ import java.util.Map;
 import codechicken.nei.recipe.Recipe.RecipeId;
 
 /**
- * Per-craft delay ramp for auto-crafting. First craft of a recipe is instant,
- * then the delay decays geometrically toward a floor. Each recipe keeps its own
- * ramp for the run, so switching away and back resumes rather than restarts. At
- * floor (max) speed crafts are batched. Pure logic; does not sleep.
+ * Per-craft delay ramp for auto-crafting. A recipe starts at the start delay and
+ * decays geometrically toward a floor. Each recipe keeps its own ramp for the
+ * run, so switching away and back resumes rather than restarts. At floor (max)
+ * speed crafts are batched. Pure logic; does not sleep.
  */
 public class CraftRampThrottle {
 
-    public static final long START_DELAY_MS = 500L; // delay before the 2nd craft
+    public static final long START_DELAY_MS = 500L; // delay before the 1st craft
     public static final long FLOOR_DELAY_MS = 50L;  // fastest allowed (cap)
     public static final double DECAY = 0.85D;
     public static final int BULK_CRAFTS = 8;        // crafts per tick once maxed out
@@ -32,16 +32,9 @@ public class CraftRampThrottle {
 
     private final Map<RecipeId, Long> delays = new HashMap<>();
 
-    /** Next tick for {@code id}: instant single craft the first time, then a decaying delay. */
+    /** Next tick for {@code id}: the start delay the first time, then a decaying delay. */
     public Tick next(RecipeId id) {
-        final Long stored = this.delays.get(id);
-
-        if (stored == null) {
-            this.delays.put(id, START_DELAY_MS);
-            return new Tick(0L, 1);
-        }
-
-        final long delay = stored;
+        final long delay = this.delays.getOrDefault(id, START_DELAY_MS);
         this.delays.put(id, Math.max(FLOOR_DELAY_MS, Math.round(delay * DECAY)));
         return new Tick(delay, delay == FLOOR_DELAY_MS ? BULK_CRAFTS : 1);
     }

--- a/src/main/java/codechicken/nei/recipe/CraftRampThrottle.java
+++ b/src/main/java/codechicken/nei/recipe/CraftRampThrottle.java
@@ -1,33 +1,48 @@
 package codechicken.nei.recipe;
 
-import java.util.Objects;
+import java.util.HashMap;
+import java.util.Map;
 
 import codechicken.nei.recipe.Recipe.RecipeId;
 
 /**
  * Per-craft delay ramp for auto-crafting. First craft of a recipe is instant,
- * then the delay decays geometrically toward a floor. Changing the recipe
- * resets the ramp. Pure logic; does not sleep.
+ * then the delay decays geometrically toward a floor. Each recipe keeps its own
+ * ramp for the run, so switching away and back resumes rather than restarts. At
+ * floor (max) speed crafts are batched. Pure logic; does not sleep.
  */
 public class CraftRampThrottle {
 
     public static final long START_DELAY_MS = 500L; // delay before the 2nd craft
     public static final long FLOOR_DELAY_MS = 50L;  // fastest allowed (cap)
     public static final double DECAY = 0.85D;
+    public static final int BULK_CRAFTS = 8;        // crafts per tick once maxed out
 
-    private RecipeId current;
-    private long delayMs;
+    /** Delay to wait before a craft, and how many crafts that tick covers. */
+    public static final class Tick {
 
-    /** Delay to wait before the next craft of {@code id}; 0 for the first / after a change. */
-    public long nextDelayMs(RecipeId id) {
-        if (!Objects.equals(id, this.current)) {
-            this.current = id;
-            this.delayMs = START_DELAY_MS;
-            return 0L;
+        public final long delayMs;
+        public final int crafts;
+
+        Tick(long delayMs, int crafts) {
+            this.delayMs = delayMs;
+            this.crafts = crafts;
+        }
+    }
+
+    private final Map<RecipeId, Long> delays = new HashMap<>();
+
+    /** Next tick for {@code id}: instant single craft the first time, then a decaying delay. */
+    public Tick next(RecipeId id) {
+        final Long stored = this.delays.get(id);
+
+        if (stored == null) {
+            this.delays.put(id, START_DELAY_MS);
+            return new Tick(0L, 1);
         }
 
-        final long delay = this.delayMs;
-        this.delayMs = Math.max(FLOOR_DELAY_MS, Math.round(this.delayMs * DECAY));
-        return delay;
+        final long delay = stored;
+        this.delays.put(id, Math.max(FLOOR_DELAY_MS, Math.round(delay * DECAY)));
+        return new Tick(delay, delay == FLOOR_DELAY_MS ? BULK_CRAFTS : 1);
     }
 }

--- a/src/main/java/codechicken/nei/recipe/DefaultOverlayHandler.java
+++ b/src/main/java/codechicken/nei/recipe/DefaultOverlayHandler.java
@@ -123,6 +123,12 @@ public class DefaultOverlayHandler implements IOverlayHandler {
 
             if (craftingSlot.getHasStack() && craftingSlot.canTakeStack(firstGui.mc.thePlayer)) {
                 FastTransferManager.clickSlot(firstGui, craftingSlot.slotNumber, 0, 1);
+
+                // Output still present means it wasn't taken (e.g. inventory full); stop.
+                if (craftingSlot.getHasStack()) {
+                    break;
+                }
+
                 craft = true;
             }
 

--- a/src/test/java/codechicken/nei/recipe/CraftRampThrottleTest.java
+++ b/src/test/java/codechicken/nei/recipe/CraftRampThrottleTest.java
@@ -6,16 +6,20 @@ import static org.mockito.Mockito.mock;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import codechicken.nei.recipe.CraftRampThrottle.Tick;
 import codechicken.nei.recipe.Recipe.RecipeId;
 
 class CraftRampThrottleTest {
 
     @Test
-    @DisplayName("first craft of a recipe is instant")
+    @DisplayName("first craft of a recipe is instant and single")
     void firstCraftInstant() {
         CraftRampThrottle throttle = new CraftRampThrottle();
         RecipeId id = mock(RecipeId.class);
-        assertEquals(0L, throttle.nextDelayMs(id));
+
+        Tick tick = throttle.next(id);
+        assertEquals(0L, tick.delayMs);
+        assertEquals(1, tick.crafts);
     }
 
     @Test
@@ -24,29 +28,55 @@ class CraftRampThrottleTest {
         CraftRampThrottle throttle = new CraftRampThrottle();
         RecipeId id = mock(RecipeId.class);
 
-        assertEquals(0L, throttle.nextDelayMs(id));                 // craft 1: instant
-        assertEquals(500L, throttle.nextDelayMs(id));               // craft 2: START
-        assertEquals(425L, throttle.nextDelayMs(id));               // 500 * 0.85
-        assertEquals(361L, throttle.nextDelayMs(id));               // round(425 * 0.85)
+        assertEquals(0L, throttle.next(id).delayMs);                 // craft 1: instant
+        assertEquals(500L, throttle.next(id).delayMs);               // craft 2: START
+        assertEquals(425L, throttle.next(id).delayMs);               // 500 * 0.85
+        assertEquals(361L, throttle.next(id).delayMs);               // round(425 * 0.85)
 
-        long last = 361L;
+        Tick last = null;
         for (int i = 0; i < 50; i++) {
-            last = throttle.nextDelayMs(id);
+            last = throttle.next(id);
         }
-        assertEquals(CraftRampThrottle.FLOOR_DELAY_MS, last);       // clamped at floor
+        assertEquals(CraftRampThrottle.FLOOR_DELAY_MS, last.delayMs); // clamped at floor
     }
 
     @Test
-    @DisplayName("changing recipe resets the ramp to instant")
-    void recipeChangeResets() {
+    @DisplayName("at floor speed, crafts happen in bulk")
+    void bulkAtFloorSpeed() {
+        CraftRampThrottle throttle = new CraftRampThrottle();
+        RecipeId id = mock(RecipeId.class);
+
+        Tick tick = throttle.next(id);
+        for (int i = 0; i < 50; i++) {
+            tick = throttle.next(id);
+        }
+
+        assertEquals(CraftRampThrottle.FLOOR_DELAY_MS, tick.delayMs);
+        assertEquals(CraftRampThrottle.BULK_CRAFTS, tick.crafts);     // batched once maxed out
+    }
+
+    @Test
+    @DisplayName("crafts stay single while still ramping")
+    void singleWhileRamping() {
+        CraftRampThrottle throttle = new CraftRampThrottle();
+        RecipeId id = mock(RecipeId.class);
+
+        assertEquals(1, throttle.next(id).crafts);                   // instant
+        assertEquals(1, throttle.next(id).crafts);                   // 500
+        assertEquals(1, throttle.next(id).crafts);                   // 425
+    }
+
+    @Test
+    @DisplayName("each recipe keeps its own ramp; returning resumes, not resets")
+    void perRecipeMemoryResumes() {
         CraftRampThrottle throttle = new CraftRampThrottle();
         RecipeId a = mock(RecipeId.class);
         RecipeId b = mock(RecipeId.class);
 
-        assertEquals(0L, throttle.nextDelayMs(a));                  // a craft 1
-        assertEquals(500L, throttle.nextDelayMs(a));                // a craft 2
-        assertEquals(0L, throttle.nextDelayMs(b));                  // switch -> instant
-        assertEquals(500L, throttle.nextDelayMs(b));                // b craft 2
-        assertEquals(0L, throttle.nextDelayMs(a));                  // switch back -> instant again
+        assertEquals(0L, throttle.next(a).delayMs);                  // a craft 1
+        assertEquals(500L, throttle.next(a).delayMs);                // a craft 2
+        assertEquals(0L, throttle.next(b).delayMs);                  // b starts fresh
+        assertEquals(425L, throttle.next(a).delayMs);                // a resumes where it left off
+        assertEquals(500L, throttle.next(b).delayMs);                // b resumes its own ramp
     }
 }

--- a/src/test/java/codechicken/nei/recipe/CraftRampThrottleTest.java
+++ b/src/test/java/codechicken/nei/recipe/CraftRampThrottleTest.java
@@ -1,6 +1,7 @@
 package codechicken.nei.recipe;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.DisplayName;
@@ -10,6 +11,14 @@ import codechicken.nei.recipe.CraftRampThrottle.Tick;
 import codechicken.nei.recipe.Recipe.RecipeId;
 
 class CraftRampThrottleTest {
+
+    private static Tick rampToFloor(CraftRampThrottle throttle, RecipeId id) {
+        Tick tick = null;
+        for (int i = 0; i < 100; i++) {
+            tick = throttle.next(id);
+        }
+        return tick;
+    }
 
     @Test
     @DisplayName("first craft of a recipe uses the start delay and is single")
@@ -23,20 +32,20 @@ class CraftRampThrottleTest {
     }
 
     @Test
-    @DisplayName("same recipe decays geometrically and clamps at floor")
+    @DisplayName("same recipe decays monotonically and clamps at floor")
     void rampDecaysToFloor() {
         CraftRampThrottle throttle = new CraftRampThrottle();
         RecipeId id = mock(RecipeId.class);
 
-        assertEquals(500L, throttle.next(id).delayMs);               // craft 1: START
-        assertEquals(425L, throttle.next(id).delayMs);               // 500 * 0.85
-        assertEquals(361L, throttle.next(id).delayMs);               // round(425 * 0.85)
-
-        Tick last = null;
-        for (int i = 0; i < 50; i++) {
-            last = throttle.next(id);
+        long prev = Long.MAX_VALUE;
+        for (int i = 0; i < 5; i++) {
+            long delay = throttle.next(id).delayMs;
+            assertTrue(delay <= prev, "delay should not increase while ramping");
+            assertTrue(delay >= CraftRampThrottle.FLOOR_DELAY_MS, "delay should not drop below floor");
+            prev = delay;
         }
-        assertEquals(CraftRampThrottle.FLOOR_DELAY_MS, last.delayMs); // clamped at floor
+
+        assertEquals(CraftRampThrottle.FLOOR_DELAY_MS, rampToFloor(throttle, id).delayMs);
     }
 
     @Test
@@ -45,13 +54,9 @@ class CraftRampThrottleTest {
         CraftRampThrottle throttle = new CraftRampThrottle();
         RecipeId id = mock(RecipeId.class);
 
-        Tick tick = throttle.next(id);
-        for (int i = 0; i < 50; i++) {
-            tick = throttle.next(id);
-        }
-
+        Tick tick = rampToFloor(throttle, id);
         assertEquals(CraftRampThrottle.FLOOR_DELAY_MS, tick.delayMs);
-        assertEquals(CraftRampThrottle.BULK_CRAFTS, tick.crafts);     // batched once maxed out
+        assertEquals(CraftRampThrottle.BULK_CRAFTS, tick.crafts);
     }
 
     @Test
@@ -60,22 +65,23 @@ class CraftRampThrottleTest {
         CraftRampThrottle throttle = new CraftRampThrottle();
         RecipeId id = mock(RecipeId.class);
 
-        assertEquals(1, throttle.next(id).crafts);                   // 500
-        assertEquals(1, throttle.next(id).crafts);                   // 425
-        assertEquals(1, throttle.next(id).crafts);                   // 361
+        assertEquals(1, throttle.next(id).crafts);
+        assertEquals(1, throttle.next(id).crafts);
     }
 
     @Test
-    @DisplayName("each recipe keeps its own ramp; returning resumes, not resets")
-    void perRecipeMemoryResumes() {
+    @DisplayName("recipe change reduces momentum but does not fully reset")
+    void recipeChangeReducesMomentum() {
         CraftRampThrottle throttle = new CraftRampThrottle();
         RecipeId a = mock(RecipeId.class);
         RecipeId b = mock(RecipeId.class);
 
-        assertEquals(500L, throttle.next(a).delayMs);                // a craft 1
-        assertEquals(425L, throttle.next(a).delayMs);                // a craft 2
-        assertEquals(500L, throttle.next(b).delayMs);                // b starts fresh
-        assertEquals(361L, throttle.next(a).delayMs);                // a resumes where it left off
-        assertEquals(425L, throttle.next(b).delayMs);                // b resumes its own ramp
+        // Ramp A to full speed (floor).
+        assertEquals(CraftRampThrottle.FLOOR_DELAY_MS, rampToFloor(throttle, a).delayMs);
+
+        // Switching to B slows down, but keeps momentum: slower than floor, faster than a cold start.
+        long afterSwitch = throttle.next(b).delayMs;
+        assertTrue(afterSwitch > CraftRampThrottle.FLOOR_DELAY_MS, "switch should reduce momentum");
+        assertTrue(afterSwitch < CraftRampThrottle.START_DELAY_MS, "switch should not fully reset");
     }
 }

--- a/src/test/java/codechicken/nei/recipe/CraftRampThrottleTest.java
+++ b/src/test/java/codechicken/nei/recipe/CraftRampThrottleTest.java
@@ -12,13 +12,13 @@ import codechicken.nei.recipe.Recipe.RecipeId;
 class CraftRampThrottleTest {
 
     @Test
-    @DisplayName("first craft of a recipe is instant and single")
-    void firstCraftInstant() {
+    @DisplayName("first craft of a recipe uses the start delay and is single")
+    void firstCraftUsesStartDelay() {
         CraftRampThrottle throttle = new CraftRampThrottle();
         RecipeId id = mock(RecipeId.class);
 
         Tick tick = throttle.next(id);
-        assertEquals(0L, tick.delayMs);
+        assertEquals(CraftRampThrottle.START_DELAY_MS, tick.delayMs);
         assertEquals(1, tick.crafts);
     }
 
@@ -28,8 +28,7 @@ class CraftRampThrottleTest {
         CraftRampThrottle throttle = new CraftRampThrottle();
         RecipeId id = mock(RecipeId.class);
 
-        assertEquals(0L, throttle.next(id).delayMs);                 // craft 1: instant
-        assertEquals(500L, throttle.next(id).delayMs);               // craft 2: START
+        assertEquals(500L, throttle.next(id).delayMs);               // craft 1: START
         assertEquals(425L, throttle.next(id).delayMs);               // 500 * 0.85
         assertEquals(361L, throttle.next(id).delayMs);               // round(425 * 0.85)
 
@@ -61,9 +60,9 @@ class CraftRampThrottleTest {
         CraftRampThrottle throttle = new CraftRampThrottle();
         RecipeId id = mock(RecipeId.class);
 
-        assertEquals(1, throttle.next(id).crafts);                   // instant
         assertEquals(1, throttle.next(id).crafts);                   // 500
         assertEquals(1, throttle.next(id).crafts);                   // 425
+        assertEquals(1, throttle.next(id).crafts);                   // 361
     }
 
     @Test
@@ -73,10 +72,10 @@ class CraftRampThrottleTest {
         RecipeId a = mock(RecipeId.class);
         RecipeId b = mock(RecipeId.class);
 
-        assertEquals(0L, throttle.next(a).delayMs);                  // a craft 1
-        assertEquals(500L, throttle.next(a).delayMs);                // a craft 2
-        assertEquals(0L, throttle.next(b).delayMs);                  // b starts fresh
-        assertEquals(425L, throttle.next(a).delayMs);                // a resumes where it left off
-        assertEquals(500L, throttle.next(b).delayMs);                // b resumes its own ramp
+        assertEquals(500L, throttle.next(a).delayMs);                // a craft 1
+        assertEquals(425L, throttle.next(a).delayMs);                // a craft 2
+        assertEquals(500L, throttle.next(b).delayMs);                // b starts fresh
+        assertEquals(361L, throttle.next(a).delayMs);                // a resumes where it left off
+        assertEquals(425L, throttle.next(b).delayMs);                // b resumes its own ramp
     }
 }

--- a/src/test/java/codechicken/nei/recipe/CraftRampThrottleTest.java
+++ b/src/test/java/codechicken/nei/recipe/CraftRampThrottleTest.java
@@ -1,0 +1,52 @@
+package codechicken.nei.recipe;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import codechicken.nei.recipe.Recipe.RecipeId;
+
+class CraftRampThrottleTest {
+
+    @Test
+    @DisplayName("first craft of a recipe is instant")
+    void firstCraftInstant() {
+        CraftRampThrottle throttle = new CraftRampThrottle();
+        RecipeId id = mock(RecipeId.class);
+        assertEquals(0L, throttle.nextDelayMs(id));
+    }
+
+    @Test
+    @DisplayName("same recipe decays geometrically and clamps at floor")
+    void rampDecaysToFloor() {
+        CraftRampThrottle throttle = new CraftRampThrottle();
+        RecipeId id = mock(RecipeId.class);
+
+        assertEquals(0L, throttle.nextDelayMs(id));                 // craft 1: instant
+        assertEquals(500L, throttle.nextDelayMs(id));               // craft 2: START
+        assertEquals(425L, throttle.nextDelayMs(id));               // 500 * 0.85
+        assertEquals(361L, throttle.nextDelayMs(id));               // round(425 * 0.85)
+
+        long last = 361L;
+        for (int i = 0; i < 50; i++) {
+            last = throttle.nextDelayMs(id);
+        }
+        assertEquals(CraftRampThrottle.FLOOR_DELAY_MS, last);       // clamped at floor
+    }
+
+    @Test
+    @DisplayName("changing recipe resets the ramp to instant")
+    void recipeChangeResets() {
+        CraftRampThrottle throttle = new CraftRampThrottle();
+        RecipeId a = mock(RecipeId.class);
+        RecipeId b = mock(RecipeId.class);
+
+        assertEquals(0L, throttle.nextDelayMs(a));                  // a craft 1
+        assertEquals(500L, throttle.nextDelayMs(a));                // a craft 2
+        assertEquals(0L, throttle.nextDelayMs(b));                  // switch -> instant
+        assertEquals(500L, throttle.nextDelayMs(b));                // b craft 2
+        assertEquals(0L, throttle.nextDelayMs(a));                  // switch back -> instant again
+    }
+}


### PR DESCRIPTION
## Summary
Adds an artificial throttle to NEI autocrafting that is very similar to https://ficsit.app/mod/FasterManualCraftingRedux in that the crafting starts slow, then ramps up, even switching to bulk crafting if needed. If a different recipe is hit, it will decelerate a little, but not fully back at the initial speed, and then ramp back up.


## Checklist
- [X] I have tested this PR in DevEnv
- [X] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
