### PR TITLE
Bookmarks Chain: fix container item multiplier limit

### DIFF
--- a/src/main/java/codechicken/nei/recipe/chain/RecipeChainMath.java
+++ b/src/main/java/codechicken/nei/recipe/chain/RecipeChainMath.java
@@ -411,8 +411,9 @@ public class RecipeChainMath {
                     final ContainerItemResult result = getToolsContainerItems(itemStack, steps);
 
                     if (result.stack == null) {
-                        multiplier = steps / (steps - result.leftSteps);
-                        steps = steps % (steps - result.leftSteps);
+                        final long stepsPerReplacement = steps - result.leftSteps;
+                        multiplier = Math.min(steps / stepsPerReplacement, maxAmount - shiftAmount);
+                        steps -= multiplier * stepsPerReplacement;
                     } else {
                         steps = result.leftSteps;
                     }


### PR DESCRIPTION
## Summary
Fixed the usage limit for durability items from the inventory in crafting chains


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
