### PR TITLE
Fix Untranslator With Broken Item

### DIFF
--- a/src/main/java/codechicken/nei/util/ItemUntranslator.java
+++ b/src/main/java/codechicken/nei/util/ItemUntranslator.java
@@ -252,13 +252,20 @@ public class ItemUntranslator {
         return this.processedNames.computeIfAbsent(guidKey, stackKey -> {
             String displayName = this.secondNames.get(stackKey);
 
-            if (displayName == null) {
-                final String guid = findBestGUIDForLookup(stack);
-                displayName = this.secondNames
-                        .computeIfAbsent(guid == null ? stackKey : guid, g -> getFallbackDisplayName(stack));
+            try {
+
+                if (displayName == null) {
+                    final String guid = findBestGUIDForLookup(stack);
+                    displayName = this.secondNames
+                            .computeIfAbsent(guid == null ? stackKey : guid, g -> getFallbackDisplayName(stack));
+                }
+
+                return displayName.equals(stripFormatting(stack.getDisplayName())) ? "" : displayName;
+            } catch (Throwable e) {
+                NEIClientConfig.logger.warn("Failed to get display name for itemstack {}", stack, e);
             }
 
-            return displayName.equals(stripFormatting(stack.getDisplayName())) ? "" : displayName;
+            return displayName != null ? displayName : "";
         });
     }
 


### PR DESCRIPTION
## Summary
issue:
```java.lang.NullPointerException: Cannot invoke "String.trim()" because the return value of "net.minecraft.util.EnumChatFormatting.func_110646_a(String)" is null
    at codechicken.nei.util.ItemUntranslator.stripFormatting(ItemUntranslator.java:241)
    at codechicken.nei.util.ItemUntranslator.lambda$getItemStackDisplayName$1(ItemUntranslator.java:261)
    at java.util.HashMap.computeIfAbsent(HashMap.java:1228)
    at codechicken.nei.util.ItemUntranslator.getItemStackDisplayName(ItemUntranslator.java:252)
    at codechicken.nei.guihook.GuiContainerManager.renderToolTips(GuiContainerManager.java:620)
    at net.minecraft.client.gui.inventory.GuiContainer.drawScreen(GuiContainer.java:166)
    at net.minecraft.client.renderer.InventoryEffectRenderer.drawScreen(InventoryEffectRenderer.java:1535)
    at net.minecraft.client.gui.inventory.GuiContainerCreative.drawScreen(GuiContainerCreative.java:638)
    at net.minecraft.client.renderer.EntityRenderer.updateCameraAndRender(EntityRenderer.java:1061)
    at net.minecraft.client.Minecraft.redirect$zzn000$angelica$skipRenderWhenIconified(Minecraft.java:3951)
    at net.minecraft.client.Minecraft.runGameLoop(Minecraft.java:1001)
    at net.minecraft.client.Minecraft.run(Minecraft.java:8110)
    at net.minecraft.client.main.Main.main(SourceFile:148)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    at java.lang.reflect.Method.invoke(Method.java:580)
    at net.minecraft.launchwrapper.Launch.rfb$realLaunch(Launch.java:250)
    at net.minecraft.launchwrapper.Launch.launch(Launch.java:35)
    at net.minecraft.launchwrapper.Launch.main(Launch.java:60)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    at java.lang.reflect.Method.invoke(Method.java:580)
    at com.gtnewhorizons.retrofuturabootstrap.Main.main(Main.java:207)
    at com.gtnewhorizons.retrofuturabootstrap.MainStartOnFirstThread.lambda$main$1(MainStartOnFirstThread.java:47)
    at java.lang.Thread.run(Thread.java:1583)
```

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
