### PR TITLE
Cache enum `.values()`

### DIFF
--- a/src/main/java/codechicken/nei/api/ItemInfo.java
+++ b/src/main/java/codechicken/nei/api/ItemInfo.java
@@ -78,6 +78,7 @@ import cpw.mods.fml.common.registry.GameRegistry.UniqueIdentifier;
 public class ItemInfo {
 
     public enum Layout {
+
         HEADER,
         BODY,
         FOOTER;

--- a/src/main/java/codechicken/nei/api/ItemInfo.java
+++ b/src/main/java/codechicken/nei/api/ItemInfo.java
@@ -77,10 +77,12 @@ import cpw.mods.fml.common.registry.GameRegistry.UniqueIdentifier;
  */
 public class ItemInfo {
 
-    public static enum Layout {
+    public enum Layout {
         HEADER,
         BODY,
-        FOOTER
+        FOOTER;
+
+        public static final Layout[] VALUES = values();
     }
 
     public static final ArrayListMultimap<Layout, IHighlightHandler> highlightHandlers = ArrayListMultimap.create();
@@ -472,7 +474,7 @@ public class ItemInfo {
             MovingObjectPosition mop) {
         List<String> retString = new ArrayList<>();
 
-        for (ItemInfo.Layout layout : ItemInfo.Layout.values())
+        for (ItemInfo.Layout layout : Layout.VALUES)
             for (IHighlightHandler handler : ItemInfo.highlightHandlers.get(layout))
                 retString = handler.handleTextData(itemStack, world, player, mop, retString, layout);
 


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
caching enum values() calls that got called more than 500 times during my little playtest.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge