### PR TITLE
New worlds ignoring global cheatmode

### DIFF
--- a/src/main/java/codechicken/nei/NEIClientConfig.java
+++ b/src/main/java/codechicken/nei/NEIClientConfig.java
@@ -882,9 +882,14 @@ public class NEIClientConfig {
 
             world = new ConfigSet(new File(specificDir, "NEI.dat"), new ConfigFile(new File(specificDir, "NEI.cfg")));
 
-            if (newWorld && Minecraft.getMinecraft().isSingleplayer()) {
-                world.config.getTag("inventory.cheatmode")
-                        .setIntValue(NEIClientUtils.mc().playerController.isInCreativeMode() ? 2 : 0);
+            if (newWorld && Minecraft.getMinecraft().isSingleplayer() && getLockedMode() == -1) {
+                final int globalMode = global.config.getTag("inventory.cheatmode").getIntValue();
+                final int worldMode = Math
+                        .min(globalMode, NEIClientUtils.mc().playerController.isInCreativeMode() ? 2 : 0);
+
+                if (worldMode != globalMode) {
+                    world.config.getTag("inventory.cheatmode").setIntValue(worldMode);
+                }
             }
 
             bootNEI();

--- a/src/main/java/codechicken/nei/api/NEIInfo.java
+++ b/src/main/java/codechicken/nei/api/NEIInfo.java
@@ -14,8 +14,9 @@ public class NEIInfo {
 
     public static void load(World world) {
         OptionCycled modeOption = (OptionCycled) NEIClientConfig.getOptionList().getOption("inventory.cheatmode");
+        final boolean worldConfig = NEIClientConfig.isWorldSpecific("inventory.cheatmode");
         // kept alive so the WeakReference in Option.slotRef isn't GC'd before copyGlobals/cycle use it
-        GuiOptionList env = modeOption.parent.synthesizeEnvironment(false);
+        GuiOptionList env = modeOption.parent.synthesizeEnvironment(worldConfig);
         if (!modeOption.optionValid(modeOption.value())) {
             modeOption.copyGlobals();
             modeOption.cycle();


### PR DESCRIPTION
Fixed bug where, new singleplayer worlds ignore the global config.

## Summary
NEIClientConfig.loadworld was allocating cheatmode without first checking the current global value.

Now, loadworld defaults to the global value unless the gamemode requires lower access (Survival mode -> Recipe Mode)


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge

Closes #952 