### PR TITLE
Fix Autocrafting With GTTools

### DIFF
--- a/src/main/java/codechicken/nei/recipe/DefaultOverlayHandler.java
+++ b/src/main/java/codechicken/nei/recipe/DefaultOverlayHandler.java
@@ -36,6 +36,7 @@ public class DefaultOverlayHandler implements IOverlayHandler {
         public int numSlots;
         public int recipeAmount;
         public boolean isContainerItem = false;
+        public long damagePerContainerCraft;
     }
 
     public static class IngredientDistribution {
@@ -264,6 +265,11 @@ public class DefaultOverlayHandler implements IOverlayHandler {
 
             final int maxStackSize = istack.stack.getMaxStackSize();
             if (maxStackSize == 1 && istack.isContainerItem) {
+
+                if (istack.damagePerContainerCraft > 0) {
+                    quantity = (int) Math.min(quantity, istack.damagePerContainerCraft);
+                }
+
                 // If non-stackable, fill up as much as possible of the other ingredients
                 continue;
             }
@@ -377,7 +383,14 @@ public class DefaultOverlayHandler implements IOverlayHandler {
                         final NBTTagCompound tagCompound = pstack.getTagCompound();
 
                         if (tagCompound != null && tagCompound.hasKey("GT.ToolStats")) {
+                            final NBTTagCompound toolStats = tagCompound.getCompoundTag("GT.ToolStats");
+                            final long damagePerContainerCraft = getGTToolDamagePerContainerCraft(pstack);
+                            final long maxDamage = toolStats.getLong("MaxDamage");
+                            final long damage = toolStats.getLong("Damage");
+
                             istack.isContainerItem = true;
+                            istack.damagePerContainerCraft = (maxDamage - damage + damagePerContainerCraft - 1)
+                                    / damagePerContainerCraft;
                         } else {
                             final boolean isPausedItemDamageSound = StackInfo.isPausedItemDamageSound();
                             StackInfo.pauseItemDamageSound(true);
@@ -393,6 +406,19 @@ public class DefaultOverlayHandler implements IOverlayHandler {
                 }
             }
         }
+    }
+
+    private int getGTToolDamagePerContainerCraft(ItemStack aStack) {
+
+        try {
+            final Object toolStats = aStack.getItem().getClass().getMethod("getToolStats", ItemStack.class)
+                    .invoke(aStack.getItem(), aStack);
+            return (int) toolStats.getClass().getMethod("getToolDamagePerContainerCraft").invoke(toolStats);
+        } catch (Throwable th) {
+            th.printStackTrace();
+        }
+
+        return 0;
     }
 
     protected List<DistributedIngred> getPermutationIngredients(List<PositionedStack> ingredients) {


### PR DESCRIPTION
## Summary
When crafting planks using a tool with insufficient durability, some of the planks would get crafted without the tool being used at all.
The same bug persists when the player uses shift+click.

### Before
https://github.com/user-attachments/assets/099d0275-1b50-41de-a5be-ad64d8aa6917

### After
https://github.com/user-attachments/assets/58ddbaf8-2587-4f0b-87ca-ba742fe6f6e7

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
