### PR TITLE
Fix crash when recipe search results change mid-rebuild

### DIFF
--- a/src/main/java/codechicken/nei/recipe/RecipePageManager.java
+++ b/src/main/java/codechicken/nei/recipe/RecipePageManager.java
@@ -50,12 +50,13 @@ public class RecipePageManager {
 
         final int heightAvailable = this.container.getVisibleHeight();
         final int width = Math.max(166, this.handlerInfo.getWidth());
-        final int numRecipes = getNumRecipes();
+        final List<Integer> searchRecipes = this.handler.getFilteredRecipes();
+        final int numRecipes = searchRecipes.size();
         List<Widget> widgets = new ArrayList<>();
         int shiftY = 0;
 
         for (int i = 0; i < numRecipes; i++) {
-            final int recipeIndex = this.handler.ref(i);
+            final int recipeIndex = searchRecipes.get(i);
             final NEIRecipeWidget widget = RecipeHandlerRef.of(this.handler.original, recipeIndex).getRecipeWidget();
             widget.w = width;
 

--- a/src/main/java/codechicken/nei/recipe/SearchRecipeHandler.java
+++ b/src/main/java/codechicken/nei/recipe/SearchRecipeHandler.java
@@ -97,6 +97,22 @@ class SearchRecipeHandler<H extends IRecipeHandler> {
         this.searchRecipes = searchRecipes;
     }
 
+    public List<Integer> getFilteredRecipes() {
+
+        if (this.searchRecipes == null) {
+            return this.filteredRecipes;
+        }
+
+        final List<Integer> search = this.searchRecipes;
+        final List<Integer> resolved = new ArrayList<>(search.size());
+
+        for (int idx : search) {
+            resolved.add(this.filteredRecipes.get(idx));
+        }
+
+        return resolved;
+    }
+
     public int ref(int index) {
 
         if (searchRecipes != null) {


### PR DESCRIPTION
## Summary
searchRecipes could get swapped by the background search thread
between numRecipes() and ref() calls in the same page rebuild,
causing IndexOutOfBoundsException

```
java.lang.IndexOutOfBoundsException: Index 8822 out of bounds for length 0
    at jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:100)
    at jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106)
    at jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302)
    at java.util.Objects.checkIndex(Objects.java:365)
    at java.util.ArrayList.get(ArrayList.java:428)
    at codechicken.nei.recipe.SearchRecipeHandler.ref(SearchRecipeHandler.java:103)
    at codechicken.nei.recipe.RecipePageManager.rebuildPages(RecipePageManager.java:58)
    at codechicken.nei.recipe.GuiRecipe.refreshContainer(GuiRecipe.java:444)
    at codechicken.nei.recipe.GuiRecipe.updateScreen(GuiRecipe.java:798)
    at net.minecraft.client.Minecraft.runTick(Minecraft.java:1661)
    at net.minecraft.client.Minecraft.runGameLoop(Minecraft.java:973)
    at net.minecraft.client.Minecraft.run(Minecraft.java:9610)
    at net.minecraft.client.main.Main.main(SourceFile:148)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
    at java.lang.reflect.Method.invoke(Method.java:565)
    at net.minecraft.launchwrapper.Launch.rfb$realLaunch(Launch.java:250)
    at net.minecraft.launchwrapper.Launch.launch(Launch.java:35)
    at net.minecraft.launchwrapper.Launch.main(Launch.java:60)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
    at java.lang.reflect.Method.invoke(Method.java:565)
    at com.gtnewhorizons.retrofuturabootstrap.Main.main(Main.java:207)
    at com.gtnewhorizons.retrofuturabootstrap.MainStartOnFirstThread.lambda$main$1(MainStartOnFirstThread.java:47)
    at java.lang.Thread.run(Thread.java:1474)
```


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
