### PR TITLE
ItemFluidDisplay/getSubItems skips the last fluid

### DIFF
--- a/src/main/java/codechicken/nei/item/ItemFluidDisplay.java
+++ b/src/main/java/codechicken/nei/item/ItemFluidDisplay.java
@@ -181,7 +181,7 @@ public class ItemFluidDisplay extends Item implements IFluidContainerItem {
     @Override
     @SideOnly(Side.CLIENT)
     public void getSubItems(Item aItem, CreativeTabs aTab, List<ItemStack> aList) {
-        for (int i = 0, j = FluidRegistry.getMaxID(); i < j; i++) {
+        for (int i = 0, j = FluidRegistry.getMaxID(); i <= j; i++) {
             final Fluid fluid = FluidRegistry.getFluid(i);
             if (fluid == null) {
                 continue;


### PR DESCRIPTION
## Summary
getSubItems in ItemFluidDisplay skips the last registered fluid, so changing < to <= in the for loop will fix it.

Not sure if I need to test this since it’s a single symbol change but I can if needed

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
